### PR TITLE
refactor: replace Box<dyn Error> with anyhow across all crates

### DIFF
--- a/.crumbs/improve-error-handling-by-using-a-proper-error-struct.md
+++ b/.crumbs/improve-error-handling-by-using-a-proper-error-struct.md
@@ -1,14 +1,13 @@
 ---
 id: id3-chf
 title: Replace `Box<dyn Error>` with `anyhow` for error handling
-status: open
+status: closed
 type: task
 priority: 1
 tags: []
 created: 2026-03-07
-updated: 2026-03-08
-closed_reason: ''
-dependencies: []
+updated: 2026-06-07
+phase: ''
 ---
 
 # Replace `Box<dyn Error>` with `anyhow` for error handling
@@ -28,3 +27,7 @@ The codebase uses `Box<dyn Error>` everywhere with `format!("...").into()` for e
 - Replace `Result<T, Box<dyn Error>>` with `anyhow::Result<T>` across all crates (`common`, `id3tag`, `id3show`, `id3export`)
 - Replace `format!("...").into()` patterns with `.context()`
 - Replace `return Err(format!(...).into())` with `bail!()`
+
+[start] 2026-06-07 15:58:12
+
+[stop]  2026-06-07 16:34:36  36m 24s

--- a/.crumbs/improve-error-handling-by-using-a-proper-error-struct.md
+++ b/.crumbs/improve-error-handling-by-using-a-proper-error-struct.md
@@ -7,7 +7,8 @@ priority: 1
 tags: []
 created: 2026-03-07
 updated: 2026-06-07
-phase: ''
+closed_reason: ''
+dependencies: []
 ---
 
 # Replace `Box<dyn Error>` with `anyhow` for error handling

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -382,6 +382,7 @@ checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 name = "common"
 version = "0.1.7"
 dependencies = [
+ "anyhow",
  "assay",
  "clap",
  "glob",
@@ -782,6 +783,7 @@ dependencies = [
 name = "id3cli-gen"
 version = "0.1.4"
 dependencies = [
+ "anyhow",
  "clap_complete",
  "clap_complete_fig",
  "clap_mangen",
@@ -793,6 +795,7 @@ dependencies = [
 name = "id3export"
 version = "0.7.3"
 dependencies = [
+ "anyhow",
  "ape",
  "clap",
  "common",
@@ -814,6 +817,7 @@ dependencies = [
 name = "id3show"
 version = "0.2.7"
 dependencies = [
+ "anyhow",
  "ape",
  "clap",
  "common",
@@ -829,6 +833,7 @@ dependencies = [
 name = "id3tag"
 version = "0.16.0"
 dependencies = [
+ "anyhow",
  "ape",
  "clap",
  "common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ strip = true
 # panic = "unwind"
 
 [workspace.dependencies]
+anyhow = "1"
 ape = "0"
 clap = { version = "4.6.1", features = ["cargo"] }
 dsf = "0.2.2"

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -11,6 +11,7 @@ homepage = "https://github.com/evensolberg/id3tools/common/"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+anyhow.workspace = true
 clap = { workspace = true }
 log = { workspace = true }
 log4rs = { workspace = true }

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "common"
-version = "0.1.7"
+version = "0.2.0"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/common/src/log.rs
+++ b/common/src/log.rs
@@ -11,15 +11,16 @@ use log4rs::{
     filter::threshold::ThresholdFilter,
     Config,
 };
-use std::error::Error;
 use std::path::Path;
+
+use anyhow::Result;
 
 /// Creates a log configuration for the application.
 ///
 /// # Errors
 ///
 /// - `init_file()` failure
-pub fn build_logger(config_filename: &str) -> Result<(), Box<dyn Error>> {
+pub fn build_logger(config_filename: &str) -> Result<()> {
     let path = Path::new(&shellexpand::tilde(&config_filename).to_string()).to_owned();
     if path.exists() {
         log4rs::init_file(path, log4rs::config::Deserializers::default())?;

--- a/common/src/shared.rs
+++ b/common/src/shared.rs
@@ -338,7 +338,7 @@ pub fn split_val(value: &str) -> Result<(u16, u16)> {
 /// `filename: &str` - the name of the file to be used as the example. The function will get the extension and look for the number of files with the same extension.
 ///
 /// # Returns
-/// `Result<String, Box<dyn Error>>` - a formatted string with the number of files found, or an error if something went wrong.
+/// `Result<String>` - a formatted string with the number of files found, or an error if something went wrong.
 ///
 /// # Errors
 /// - Returns an error if unable to get the directory name from the fielname.
@@ -442,7 +442,7 @@ where
 /// `filename: &str` - the name of the file for which we need the full path
 ///
 /// # Returns
-/// `Result<std::path::PathBuf, Box<dyn Error>>` - a `PathBuf` containing the full directory path to the file if succcessful.
+/// `Result<std::path::PathBuf>` - a `PathBuf` containing the full directory path to the file if succcessful.
 ///
 /// # Errors
 ///

--- a/common/src/shared.rs
+++ b/common/src/shared.rs
@@ -3,8 +3,9 @@
 use std::ffi::OsStr;
 use std::path::Path;
 use std::time::UNIX_EPOCH;
-use std::{error::Error, time::SystemTime};
+use std::time::SystemTime;
 
+use anyhow::{bail, Context, Result};
 use infer::{MatcherType, Type};
 
 use crate::file_types::FileTypes;
@@ -128,10 +129,10 @@ where
 /// # Errors
 ///
 /// - If we can't infer the file type from path, we give an error
-pub fn get_mime_type(filename: &str) -> Result<String, Box<dyn Error>> {
+pub fn get_mime_type(filename: &str) -> Result<String> {
     // Read the file and check the mime type
     let Some(file_type) = infer::get_from_path(filename)? else {
-        return Err("File type not supported".into());
+        bail!("File type not supported");
     };
 
     Ok(file_type.mime_type().to_string())
@@ -154,12 +155,12 @@ pub fn get_extension(filename: &str) -> String {
 /// # Errors
 ///
 /// - `infer::get_from_path()` fails
-pub fn get_file_type(filename: &str) -> Result<FileTypes, Box<dyn Error>> {
+pub fn get_file_type(filename: &str) -> Result<FileTypes> {
     // return the file type
     let file_type = infer::get_from_path(filename)?;
     log::debug!("File type = {file_type:?}");
     let Some(file_type) = file_type else {
-        return Err("File type not supported".into());
+        bail!("File type not supported");
     };
 
     let ft;
@@ -176,7 +177,7 @@ pub fn get_file_type(filename: &str) -> Result<FileTypes, Box<dyn Error>> {
         if mp4vec.contains(&ext.as_str()) {
             ft = FileTypes::M4A;
         } else {
-            return Err("File type not supported".into());
+            bail!("File type not supported");
         }
     }
 
@@ -305,24 +306,24 @@ pub fn need_split(value: &str) -> bool {
 /// # Errors
 ///
 /// - Returns an error if the split pattern can't be found.
-pub fn split_val(value: &str) -> Result<(u16, u16), Box<dyn Error>> {
+pub fn split_val(value: &str) -> Result<(u16, u16)> {
     let split_str: Vec<&str>;
     if value.contains("of") {
         split_str = value.split("of").collect();
     } else if value.contains('/') {
         split_str = value.split('/').collect();
     } else {
-        return Err("Split pattern not found.".into());
+        bail!("Split pattern not found.");
     }
 
     let count = split_str[0]
         .trim()
         .parse::<u16>()
-        .map_err(|e| format!("Unable to parse count '{}': {e}", split_str[0].trim()))?;
+        .with_context(|| format!("Unable to parse count '{}'", split_str[0].trim()))?;
     let total = split_str[1]
         .trim()
         .parse::<u16>()
-        .map_err(|e| format!("Unable to parse total '{}': {e}", split_str[1].trim()))?;
+        .with_context(|| format!("Unable to parse total '{}'", split_str[1].trim()))?;
 
     // return the values (i.e., 1 of 2)
     Ok((count, total))
@@ -344,7 +345,7 @@ pub fn split_val(value: &str) -> Result<(u16, u16), Box<dyn Error>> {
 ///
 /// # Panics
 /// None.
-pub fn count_files(filename: &str) -> Result<String, Box<dyn Error>> {
+pub fn count_files(filename: &str) -> Result<String> {
     let ext = get_extension(filename);
 
     // Get just the directory part, excluding the filename
@@ -357,7 +358,7 @@ pub fn count_files(filename: &str) -> Result<String, Box<dyn Error>> {
     }
 
     if !dir.is_dir() {
-        return Err(format!("Unable to get directory name from filename {filename}.").into());
+        bail!("Unable to get directory name from filename {filename}.");
     }
 
     // Get the list of (music) files in the directory
@@ -449,7 +450,7 @@ where
 ///
 /// # Example
 /// `get_full_path_directory("/some/path/myfile.txt")` returns "/some/path/"
-pub fn directory(filename: &str) -> Result<std::path::PathBuf, Box<dyn Error>> {
+pub fn directory(filename: &str) -> Result<std::path::PathBuf> {
     let mut music_file_path = std::fs::canonicalize(filename)?;
     music_file_path = music_file_path
         .parent()

--- a/id3cli-gen/Cargo.toml
+++ b/id3cli-gen/Cargo.toml
@@ -16,6 +16,7 @@ path-guid = "DA054B79-BC09-48F5-B5C2-BC24DE91C4F3"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+anyhow.workspace = true
 # Our own package
 common = { path = "../common" }
 clap_complete = { workspace = true }

--- a/id3cli-gen/src/main.rs
+++ b/id3cli-gen/src/main.rs
@@ -1,8 +1,10 @@
 #![forbid(unsafe_code)]
 
+use anyhow::Result;
+
 // use clap_mangen;
 
-fn run() -> Result<(), Box<dyn std::error::Error>> {
+fn run() -> Result<()> {
     // Set up the command line. Ref https://docs.rs/clap for details.
     println!("Generating Fig completions for id3tag - id3tag.js");
     let mut cli = common::build_cli("latest");
@@ -28,9 +30,8 @@ fn main() {
     std::process::exit(match run() {
         Ok(()) => 0, // everying is hunky dory - exit with code 0 (success)
         Err(err) => {
-            let msg = err.to_string().replace('\"', "");
-            log::error!("{msg}");
-            eprintln!("Error: {msg}");
+            log::error!("{err:#}");
+            eprintln!("Error: {err:#}");
             1 // exit with a non-zero return code, indicating a problem
         }
     });

--- a/id3cli-gen/src/main.rs
+++ b/id3cli-gen/src/main.rs
@@ -30,8 +30,9 @@ fn main() {
     std::process::exit(match run() {
         Ok(()) => 0, // everying is hunky dory - exit with code 0 (success)
         Err(err) => {
-            log::error!("{err:#}");
-            eprintln!("Error: {err:#}");
+            let msg = format!("{err:#}").replace('"', "");
+            log::error!("{msg}");
+            eprintln!("Error: {msg}");
             1 // exit with a non-zero return code, indicating a problem
         }
     });

--- a/id3export/Cargo.toml
+++ b/id3export/Cargo.toml
@@ -10,6 +10,7 @@ description = "Export ID3 tags to CSV for analysis."
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+anyhow.workspace = true
 ape = { workspace = true }
 clap = { workspace = true }
 csv = { workspace = true }

--- a/id3export/src/main.rs
+++ b/id3export/src/main.rs
@@ -5,7 +5,7 @@ mod build_cli;
 mod stats;
 mod tracks;
 
-use std::error::Error;
+use anyhow::Result;
 
 use crate::{stats::calc_avg, tracks::Reader};
 use build_cli::build_cli;
@@ -16,7 +16,7 @@ use stats::update_stats;
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////
 /// This is where the magic happens.
-fn run() -> Result<(), Box<dyn Error>> {
+fn run() -> Result<()> {
     // Set up the command line. Ref https://docs.rs/clap for details.
     let cli_args = build_cli().get_matches();
 
@@ -129,15 +129,14 @@ fn main() {
     std::process::exit(match run() {
         Ok(()) => 0, // everying is hunky dory - exit with code 0 (success)
         Err(err) => {
-            let msg = err.to_string().replace('\"', "");
-            log::error!("{msg}");
-            eprintln!("Error: {msg}");
+            log::error!("{err:#}");
+            eprintln!("Error: {err:#}");
             1 // exit with a non-zero return code, indicating a problem
         }
     });
 }
 
-fn write_csv(filename: &str, tracks: Vec<tracks::Track>) -> Result<(), Box<dyn Error>> {
+fn write_csv(filename: &str, tracks: Vec<tracks::Track>) -> Result<()> {
     let mut wtr = csv::WriterBuilder::new().from_path(filename)?;
 
     for track in tracks {

--- a/id3export/src/main.rs
+++ b/id3export/src/main.rs
@@ -129,8 +129,9 @@ fn main() {
     std::process::exit(match run() {
         Ok(()) => 0, // everying is hunky dory - exit with code 0 (success)
         Err(err) => {
-            log::error!("{err:#}");
-            eprintln!("Error: {err:#}");
+            let msg = format!("{err:#}").replace('"', "");
+            log::error!("{msg}");
+            eprintln!("Error: {msg}");
             1 // exit with a non-zero return code, indicating a problem
         }
     });

--- a/id3export/src/stats.rs
+++ b/id3export/src/stats.rs
@@ -1,3 +1,4 @@
+use anyhow::Result;
 use common::thousand_separated;
 use serde::Serialize;
 use std::collections::BTreeMap;
@@ -34,7 +35,7 @@ pub fn print_stats(stats: &StatsMap) {
 pub fn export_summary_csv(
     stats: &StatsMap,
     filename: &str,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> Result<()> {
     let mut wtr = csv::Writer::from_path(filename)?;
     wtr.write_record([
         "Type",

--- a/id3export/src/tracks.rs
+++ b/id3export/src/tracks.rs
@@ -354,8 +354,8 @@ impl Reader for Track {
         {
             Ok(m) => m,
             Err(e) => {
-                log::error!("Error reading MP3: {e:?}");
-                bail!("{e:?}");
+                log::error!("Error reading MP3: {e}");
+                bail!("{e}");
             }
         };
 

--- a/id3export/src/tracks.rs
+++ b/id3export/src/tracks.rs
@@ -3,7 +3,7 @@ use id3::{Tag, TagLike};
 use metaflac::block;
 use mp4ameta::{Data, Fourcc, Tag as Mp4Tag};
 use serde::Serialize;
-use std::error::Error;
+use anyhow::{bail, Result};
 
 macro_rules! mp3_tags {
     ($tags:ident, $field:ident, $self_ref:ident, $self_field:ident) => {
@@ -194,29 +194,29 @@ impl Track {
 
 /// Handles reading of various audio file formats.
 pub trait Reader {
-    fn read(&mut self) -> Result<(), Box<dyn Error>>
+    fn read(&mut self) -> Result<()>
     where
         Self: std::marker::Sized;
 
     // May move the following functions out of the trait so the trait stays simple.
 
-    fn read_flac(&mut self) -> Result<(), Box<dyn Error>>
+    fn read_flac(&mut self) -> Result<()>
     where
         Self: std::marker::Sized;
 
-    fn read_mp3(&mut self) -> Result<(), Box<dyn Error>>
+    fn read_mp3(&mut self) -> Result<()>
     where
         Self: std::marker::Sized;
 
-    fn read_mp4(&mut self) -> Result<(), Box<dyn Error>>
+    fn read_mp4(&mut self) -> Result<()>
     where
         Self: std::marker::Sized;
 
-    fn read_ape(&mut self) -> Result<(), Box<dyn Error>>
+    fn read_ape(&mut self) -> Result<()>
     where
         Self: std::marker::Sized;
 
-    fn read_dsf(&mut self) -> Result<(), Box<dyn Error>>
+    fn read_dsf(&mut self) -> Result<()>
     where
         Self: std::marker::Sized;
 }
@@ -229,9 +229,9 @@ impl Reader for Track {
     ///
     /// Returns an error if the file type is not supported.
     ///
-    fn read(&mut self) -> Result<(), Box<dyn Error>> {
+    fn read(&mut self) -> Result<()> {
         if self.path.is_none() {
-            return Err("No path provided".into());
+            bail!("No path provided");
         }
 
         let metadata = std::fs::metadata(self.path.as_ref().unwrap_or(&String::new()))?;
@@ -253,11 +253,11 @@ impl Reader for Track {
     }
 
     /// Builds a `Track` struct from a FLAC file.
-    fn read_flac(&mut self) -> Result<(), Box<dyn Error>> {
+    fn read_flac(&mut self) -> Result<()> {
         let tags = if self.path.is_some() {
             metaflac::Tag::read_from_path(self.path.as_ref().unwrap_or(&String::new()))?
         } else {
-            return Err("No path provided".into());
+            bail!("No path provided");
         };
 
         self.file_format = Some(FileTypes::Flac);
@@ -349,14 +349,13 @@ impl Reader for Track {
     }
 
     /// Builds a `Track` struct from an MP3 file.
-    fn read_mp3(&mut self) -> Result<(), Box<dyn Error>> {
+    fn read_mp3(&mut self) -> Result<()> {
         let meta = match mp3_metadata::read_from_file(self.path.as_ref().unwrap_or(&String::new()))
         {
             Ok(m) => m,
             Err(e) => {
-                let msg = format!("{e:?}");
-                log::error!("Error reading MP3: {msg}");
-                return Err(msg.into());
+                log::error!("Error reading MP3: {e:?}");
+                bail!("{e:?}");
             }
         };
 
@@ -369,7 +368,7 @@ impl Reader for Track {
         let frames = meta.frames;
 
         if frames.is_empty() {
-            return Err("No frames found".into());
+            bail!("No frames found");
         }
 
         self.bitrate = Some(u32::from(frames[0].bitrate));
@@ -408,7 +407,7 @@ impl Reader for Track {
     }
 
     /// Builds a `Track` struct from an MP4 file.
-    fn read_mp4(&mut self) -> Result<(), Box<dyn Error>> {
+    fn read_mp4(&mut self) -> Result<()> {
         let tags = Mp4Tag::read_from_path(self.path.as_ref().unwrap_or(&String::new()))?;
         let audio = tags.audio_info();
 
@@ -457,7 +456,7 @@ impl Reader for Track {
     }
 
     /// Reads an APE file. Unfortunately, the `ape` crate currently does not provide a way to read the file's duration, bitrate, etc.
-    fn read_ape(&mut self) -> Result<(), Box<dyn Error>> {
+    fn read_ape(&mut self) -> Result<()> {
         let tags = ape::read_from_path(self.path.as_ref().unwrap_or(&String::new()))?;
         log::debug!("APE tags: {tags:?}");
 
@@ -483,7 +482,7 @@ impl Reader for Track {
         Ok(())
     }
 
-    fn read_dsf(&mut self) -> Result<(), Box<dyn Error>> {
+    fn read_dsf(&mut self) -> Result<()> {
         let newpath = String::new();
         let filepath = std::path::Path::new(self.path.as_ref().unwrap_or(&newpath));
         let dsf_file = dsf::DsfFile::open(filepath)?;
@@ -510,7 +509,7 @@ impl Reader for Track {
                 .expect("ID3 tag should exist")
         } else {
             log::warn!("No ID3 tag found");
-            return Err("No ID3 tag found".into());
+            bail!("No ID3 tag found");
         };
 
         log::debug!("Tag: {tag:?}");

--- a/id3export/src/tracks.rs
+++ b/id3export/src/tracks.rs
@@ -354,8 +354,10 @@ impl Reader for Track {
         {
             Ok(m) => m,
             Err(e) => {
-                log::error!("Error reading MP3: {e}");
-                bail!("{e}");
+                bail!(
+                    "Error reading MP3 metadata from {}: {e}",
+                    self.path.as_deref().unwrap_or("<unknown>")
+                );
             }
         };
 

--- a/id3export/src/tracks.rs
+++ b/id3export/src/tracks.rs
@@ -254,11 +254,10 @@ impl Reader for Track {
 
     /// Builds a `Track` struct from a FLAC file.
     fn read_flac(&mut self) -> Result<()> {
-        let tags = if self.path.is_some() {
-            metaflac::Tag::read_from_path(self.path.as_ref().unwrap_or(&String::new()))?
-        } else {
+        let Some(path) = self.path.as_deref() else {
             bail!("No path provided");
         };
+        let tags = metaflac::Tag::read_from_path(path)?;
 
         self.file_format = Some(FileTypes::Flac);
 
@@ -350,16 +349,15 @@ impl Reader for Track {
 
     /// Builds a `Track` struct from an MP3 file.
     fn read_mp3(&mut self) -> Result<()> {
-        let meta = match mp3_metadata::read_from_file(self.path.as_ref().unwrap_or(&String::new()))
-        {
+        let Some(path) = self.path.as_deref() else {
+            bail!("No path provided");
+        };
+        let meta = match mp3_metadata::read_from_file(path) {
             Ok(m) => m,
             Err(e) => {
                 // mp3_metadata::Error does not implement std::error::Error so it cannot be
                 // chained as an anyhow source. Format it into the message as the next best option.
-                bail!(
-                    "Error reading MP3 metadata from {}: {e}",
-                    self.path.as_deref().unwrap_or("<unknown>")
-                );
+                bail!("Error reading MP3 metadata from {path}: {e}");
             }
         };
 
@@ -388,7 +386,7 @@ impl Reader for Track {
         self.sample_rate = Some(u32::from(frames[0].sampling_freq));
 
         // Use a different crate to get the metadata
-        let tag = Tag::read_from_path(self.path.as_ref().unwrap_or(&String::new()))?;
+        let tag = Tag::read_from_path(path)?;
         mp3_tag!(tag, "TPE2", self, album_artist);
         mp3_tag!(tag, "TSO2", self, album_artist_sort);
         mp3_tag!(tag, album, self, album_title);
@@ -412,7 +410,10 @@ impl Reader for Track {
 
     /// Builds a `Track` struct from an MP4 file.
     fn read_mp4(&mut self) -> Result<()> {
-        let tags = Mp4Tag::read_from_path(self.path.as_ref().unwrap_or(&String::new()))?;
+        let Some(path) = self.path.as_deref() else {
+            bail!("No path provided");
+        };
+        let tags = Mp4Tag::read_from_path(path)?;
         let audio = tags.audio_info();
 
         self.file_format = Some(FileTypes::M4A);
@@ -461,7 +462,10 @@ impl Reader for Track {
 
     /// Reads an APE file. Unfortunately, the `ape` crate currently does not provide a way to read the file's duration, bitrate, etc.
     fn read_ape(&mut self) -> Result<()> {
-        let tags = ape::read_from_path(self.path.as_ref().unwrap_or(&String::new()))?;
+        let Some(path) = self.path.as_deref() else {
+            bail!("No path provided");
+        };
+        let tags = ape::read_from_path(path)?;
         log::debug!("APE tags: {tags:?}");
 
         self.file_format = Some(FileTypes::Ape);
@@ -487,8 +491,10 @@ impl Reader for Track {
     }
 
     fn read_dsf(&mut self) -> Result<()> {
-        let newpath = String::new();
-        let filepath = std::path::Path::new(self.path.as_ref().unwrap_or(&newpath));
+        let Some(path) = self.path.as_deref() else {
+            bail!("No path provided");
+        };
+        let filepath = std::path::Path::new(path);
         let dsf_file = dsf::DsfFile::open(filepath)?;
         log::debug!("DSF file metadata: {dsf_file}");
 

--- a/id3export/src/tracks.rs
+++ b/id3export/src/tracks.rs
@@ -354,6 +354,8 @@ impl Reader for Track {
         {
             Ok(m) => m,
             Err(e) => {
+                // mp3_metadata::Error does not implement std::error::Error so it cannot be
+                // chained as an anyhow source. Format it into the message as the next best option.
                 bail!(
                     "Error reading MP3 metadata from {}: {e}",
                     self.path.as_deref().unwrap_or("<unknown>")

--- a/id3export/src/tracks.rs
+++ b/id3export/src/tracks.rs
@@ -230,14 +230,14 @@ impl Reader for Track {
     /// Returns an error if the file type is not supported.
     ///
     fn read(&mut self) -> Result<()> {
-        if self.path.is_none() {
+        let Some(path) = self.path.as_deref() else {
             bail!("No path provided");
-        }
+        };
 
-        let metadata = std::fs::metadata(self.path.as_ref().unwrap_or(&String::new()))?;
+        let metadata = std::fs::metadata(path)?;
         self.file_size = Some(metadata.len());
 
-        let file_type = FileTypes::from_filename(self.path.as_ref().unwrap_or(&String::new()));
+        let file_type = FileTypes::from_filename(path);
         log::debug!("File type: {file_type}");
         match file_type {
             FileTypes::Flac => self.read_flac()?,

--- a/id3show/Cargo.toml
+++ b/id3show/Cargo.toml
@@ -11,6 +11,7 @@ keywords = ["flac", "audio", "parser", "metadata", "display"]
 repository = "https://github.com/evensolberg/id3tools"
 
 [dependencies]
+anyhow.workspace = true
 ape = { workspace = true }
 dsf = { workspace = true }
 id3 = { workspace = true }

--- a/id3show/src/ape.rs
+++ b/id3show/src/ape.rs
@@ -1,7 +1,7 @@
 //! Read the contents of an APE file and show the metadata.
 
 use ape::{self, ItemType};
-use std::error::Error;
+use anyhow::Result;
 
 /// Show the metadata of an APE file.
 /// If `show_detail` is true, show more detailed information such as binary data (items and lengths) and locator data (items and lengths).
@@ -13,7 +13,7 @@ use std::error::Error;
 ///
 /// # Returns
 ///
-/// * `Result<(), Box<dyn Error>>` - A result that indicates whether the operation was successful.
+/// * `Result<()>` - A result that indicates whether the operation was successful.
 ///
 /// # Example
 ///
@@ -23,7 +23,7 @@ use std::error::Error;
 /// let res = id3show::show_metadata(filename, show_detail);
 /// assert!(res.is_ok());
 /// ```
-pub fn show_metadata(filename: &str, show_detail: bool) -> Result<(), Box<dyn Error>> {
+pub fn show_metadata(filename: &str, show_detail: bool) -> Result<()> {
     let tags = ape::read_from_path(filename)?;
 
     for item in tags.iter() {

--- a/id3show/src/dsf.rs
+++ b/id3show/src/dsf.rs
@@ -1,9 +1,10 @@
 //! Show DSF file metadata.
 use dsf::{self, DsfFile};
-use std::{error::Error, path::Path};
+use anyhow::{bail, Result};
+use std::path::Path;
 
 /// Performs the actual processing of DSF files.
-pub fn show_metadata(filename: &str, show_detail: bool) -> Result<(), Box<dyn Error>> {
+pub fn show_metadata(filename: &str, show_detail: bool) -> Result<()> {
     log::debug!("Filename: {filename}");
     let path = Path::new(&filename);
 
@@ -13,7 +14,7 @@ pub fn show_metadata(filename: &str, show_detail: bool) -> Result<(), Box<dyn Er
                 println!("DSF file metadata:\n\n{dsf_file}");
             }
             Err(error) => {
-                return Err(format!("Unable to read DSF file {filename}. Error: {error}").into());
+                bail!("Unable to read DSF file {filename}. Error: {error}");
             }
         }
     } else if let Some(tag) = DsfFile::open(path)?.id3_tag().clone() {
@@ -22,7 +23,7 @@ pub fn show_metadata(filename: &str, show_detail: bool) -> Result<(), Box<dyn Er
             println!("  {} = {}", frame.id(), frame.content());
         }
     } else {
-        return Err(format!("Unable to read DSF file {filename}").into());
+        bail!("Unable to read DSF file {filename}");
     }
 
     Ok(())

--- a/id3show/src/dsf.rs
+++ b/id3show/src/dsf.rs
@@ -14,7 +14,7 @@ pub fn show_metadata(filename: &str, show_detail: bool) -> Result<()> {
                 println!("DSF file metadata:\n\n{dsf_file}");
             }
             Err(error) => {
-                return Err(error).context(format!("Unable to read DSF file {filename}"));
+                return Err(error).with_context(|| format!("Unable to read DSF file {filename}"));
             }
         }
     } else if let Some(tag) = DsfFile::open(path)?.id3_tag().clone() {

--- a/id3show/src/dsf.rs
+++ b/id3show/src/dsf.rs
@@ -1,6 +1,6 @@
 //! Show DSF file metadata.
 use dsf::{self, DsfFile};
-use anyhow::{bail, Result};
+use anyhow::{bail, Context, Result};
 use std::path::Path;
 
 /// Performs the actual processing of DSF files.
@@ -14,7 +14,7 @@ pub fn show_metadata(filename: &str, show_detail: bool) -> Result<()> {
                 println!("DSF file metadata:\n\n{dsf_file}");
             }
             Err(error) => {
-                bail!("Unable to read DSF file {filename}. Error: {error}");
+                return Err(error).context(format!("Unable to read DSF file {filename}"));
             }
         }
     } else if let Some(tag) = DsfFile::open(path)?.id3_tag().clone() {

--- a/id3show/src/flac.rs
+++ b/id3show/src/flac.rs
@@ -2,7 +2,7 @@
 
 use metaflac::block;
 use metaflac::Tag;
-use std::error::Error;
+use anyhow::{bail, Result};
 
 /// Shows the metadata contents of the file provided.
 ///
@@ -14,12 +14,12 @@ use std::error::Error;
 ///
 /// **Returns:**
 ///
-/// `Result<(), Box<dyn Error>>` -- Nothing except `Ok` if things go well, otherwise an error.
+/// `Result<()>` -- Nothing except `Ok` if things go well, otherwise an error.
 ///
 /// **Example:**
 ///
 /// `flac::process("somefile.flac", &my_tags, &my_config)?;`
-pub fn show_metadata(filename: &str, show_detail: bool) -> Result<(), Box<dyn Error>> {
+pub fn show_metadata(filename: &str, show_detail: bool) -> Result<()> {
     let tags = Tag::read_from_path(filename)?;
 
     // Placeholder for duration
@@ -151,16 +151,16 @@ fn show_unknown(uk: &(u8, Vec<u8>)) {
 }
 
 #[allow(clippy::cast_precision_loss, clippy::cast_lossless)]
-fn calc_duration_seconds(samples: u64, sample_rate: u32) -> Result<f64, Box<dyn Error>> {
+fn calc_duration_seconds(samples: u64, sample_rate: u32) -> Result<f64> {
     if sample_rate == 0 {
-        return Err("Sample rate is zero".into());
+        bail!("Sample rate is zero");
     }
 
     Ok(samples as f64 / sample_rate as f64)
 }
 
 #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
-fn calc_duration_string(samples: u64, sample_rate: u32) -> Result<String, Box<dyn Error>> {
+fn calc_duration_string(samples: u64, sample_rate: u32) -> Result<String> {
     let duration = calc_duration_seconds(samples, sample_rate)?;
     let hours = (duration / 3600.0) as u32;
     let minutes = ((duration % 3600.0) / 60.0) as u32;

--- a/id3show/src/main.rs
+++ b/id3show/src/main.rs
@@ -87,8 +87,9 @@ fn main() {
     std::process::exit(match run() {
         Ok(()) => 0, // everying is hunky dory - exit with code 0 (success)
         Err(err) => {
-            log::error!("{err:#}");
-            eprintln!("Error: {err:#}");
+            let msg = format!("{err:#}").replace('"', "");
+            log::error!("{msg}");
+            eprintln!("Error: {msg}");
             1 // exit with a non-zero return code, indicating a problem
         }
     });

--- a/id3show/src/main.rs
+++ b/id3show/src/main.rs
@@ -1,6 +1,6 @@
 #![forbid(unsafe_code)]
 
-use std::{error::Error, time::Instant};
+use std::time::Instant;
 
 // Logging
 mod build_cli;
@@ -12,9 +12,11 @@ mod flac;
 mod mp3;
 mod mp4;
 
+use anyhow::Result;
+
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////
 /// This is where the magic happens.
-fn run() -> Result<(), Box<dyn Error>> {
+fn run() -> Result<()> {
     // Start timing the execution
     let now = Instant::now();
 
@@ -85,9 +87,8 @@ fn main() {
     std::process::exit(match run() {
         Ok(()) => 0, // everying is hunky dory - exit with code 0 (success)
         Err(err) => {
-            let msg = err.to_string().replace('\"', "");
-            log::error!("{msg}");
-            eprintln!("Error: {msg}");
+            log::error!("{err:#}");
+            eprintln!("Error: {err:#}");
             1 // exit with a non-zero return code, indicating a problem
         }
     });

--- a/id3show/src/mp3.rs
+++ b/id3show/src/mp3.rs
@@ -456,6 +456,8 @@ fn open_mp3(filename: &str) -> Result<MP3Metadata> {
     match meta_res {
         Ok(r) => Ok(r),
         Err(e) => {
+            // mp3_metadata::Error does not implement std::error::Error so it cannot be
+            // chained as an anyhow source. Format it into the message as the next best option.
             bail!("Unable to open {filename} for reading stream info. Error: {e}")
         }
     }

--- a/id3show/src/mp3.rs
+++ b/id3show/src/mp3.rs
@@ -456,7 +456,7 @@ fn open_mp3(filename: &str) -> Result<MP3Metadata> {
     match meta_res {
         Ok(r) => Ok(r),
         Err(e) => {
-            bail!("Unable to open {filename} for to read stream info. Error: {e}")
+            bail!("Unable to open {filename} for reading stream info. Error: {e}")
         }
     }
 }

--- a/id3show/src/mp3.rs
+++ b/id3show/src/mp3.rs
@@ -2,7 +2,7 @@ use id3::frame;
 use id3::Content;
 use id3::Tag;
 use mp3_metadata::MP3Metadata;
-use std::error::Error;
+use anyhow::{bail, Result};
 
 /// Look into an `Option<String>` and output the `String` if there is one.
 macro_rules! opt {
@@ -62,7 +62,7 @@ macro_rules! genre_vec {
 }
 
 /// Performs the actual processing of MP3 files.
-pub fn show_metadata(filename: &str, show_detail: bool) -> Result<(), Box<dyn Error>> {
+pub fn show_metadata(filename: &str, show_detail: bool) -> Result<()> {
     let meta = open_mp3(filename)?;
     let duration_string = calc_duration_string(meta.duration.as_secs_f64());
     if show_detail {
@@ -131,7 +131,7 @@ pub fn show_metadata(filename: &str, show_detail: bool) -> Result<(), Box<dyn Er
                 }
             }
             _ => {
-                return Err(format!("Unknown content type in file {filename}").into());
+                bail!("Unknown content type in file {filename}");
             }
         }
     }
@@ -451,12 +451,12 @@ fn mp3_emphasis(e: mp3_metadata::Emphasis) -> String {
 }
 
 /// Open an MP3 file for reading using the `mp3_metadata` crate and return the metadata as a result if OK.
-fn open_mp3(filename: &str) -> Result<MP3Metadata, Box<dyn Error>> {
+fn open_mp3(filename: &str) -> Result<MP3Metadata> {
     let meta_res = mp3_metadata::read_from_file(filename);
     match meta_res {
         Ok(r) => Ok(r),
         Err(e) => {
-            Err(format!("Unable to open {filename} for to read stream info. Error: {e}").into())
+            bail!("Unable to open {filename} for to read stream info. Error: {e}")
         }
     }
 }

--- a/id3show/src/mp4.rs
+++ b/id3show/src/mp4.rs
@@ -1,8 +1,8 @@
 use mp4ameta::Tag;
-use std::error::Error;
+use anyhow::Result;
 
 /// Show the MP4 metadata
-pub fn show_metadata(filename: &str, show_detail: bool) -> Result<(), Box<dyn Error>> {
+pub fn show_metadata(filename: &str, show_detail: bool) -> Result<()> {
     let tag = Tag::read_from_path(filename)?;
 
     log::trace!("Tag = {tag:?}");

--- a/id3tag/Cargo.toml
+++ b/id3tag/Cargo.toml
@@ -12,6 +12,7 @@ keywords = ["flac", "audio", "parser", "metadata"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+anyhow.workspace = true
 ape = { workspace = true }
 clap = { workspace = true }
 dsf = { workspace = true }

--- a/id3tag/src/default_values.rs
+++ b/id3tag/src/default_values.rs
@@ -244,8 +244,8 @@ impl DefaultValues {
     pub fn load_config(filename: &str) -> Result<Self> {
         let mut config_toml = String::new();
 
-        let mut file = File::open(filename)
-            .with_context(|| format!("Config file {filename} not found"))?;
+        let mut file =
+            File::open(filename).with_context(|| format!("Config file {filename} not found"))?;
 
         let bytes = file.read_to_string(&mut config_toml)?;
         if bytes == 0 {

--- a/id3tag/src/default_values.rs
+++ b/id3tag/src/default_values.rs
@@ -1,8 +1,8 @@
 //! Contains the struct and functions to maintain the configuration state.
 
 // Read default values from config file
+use anyhow::{bail, Context, Result};
 use serde::Deserialize;
-use std::error::Error;
 use std::fs::File;
 use std::io::Read;
 
@@ -208,7 +208,7 @@ impl DefaultValues {
     }
 
     /// Builds a config based on CLI arguments
-    pub fn build_config(cli: &ArgMatches) -> Result<Self, Box<dyn Error>> {
+    pub fn build_config(cli: &ArgMatches) -> Result<Self> {
         let mut cfg = Self::new();
 
         let psf_list: Vec<String> = vec![String::from("."), String::from("..")];
@@ -241,15 +241,15 @@ impl DefaultValues {
     }
 
     /// Loads the config from the supplied TOML file.
-    pub fn load_config(filename: &str) -> Result<Self, Box<dyn Error>> {
+    pub fn load_config(filename: &str) -> Result<Self> {
         let mut config_toml = String::new();
 
         let mut file = File::open(filename)
-            .map_err(|err| format!("Config file {filename} not found. Error: {err}"))?;
+            .with_context(|| format!("Config file {filename} not found"))?;
 
         let bytes = file.read_to_string(&mut config_toml)?;
         if bytes == 0 {
-            return Err(format!("Unable to read the contents of {filename}").into());
+            bail!("Unable to read the contents of {filename}");
         }
 
         let mut config = match toml::from_str(&config_toml) {
@@ -284,7 +284,7 @@ impl DefaultValues {
     /// Checks the loaded config if there is a `file_rename` present, and validates it.
     /// Also checks the CLI for a rename-file and overrides any previous config entries if it is present.
     /// Returns OK if everything went well. Returns an error if the `file_rename` is invalid.
-    fn check_for_file_rename(&mut self, args: &clap::ArgMatches) -> Result<(), Box<dyn Error>> {
+    fn check_for_file_rename(&mut self, args: &clap::ArgMatches) -> Result<()> {
         // Check if anything came from the config file and validate it
         let mut pattern = None;
         let binding = String::new();
@@ -304,9 +304,7 @@ impl DefaultValues {
 
         if let Some(pat) = pattern {
             if common::file_rename_pattern_not_ok(&pat) {
-                return Err(
-                    format!("File rename pattern {pat} likely won't create unique files.").into(),
-                );
+                bail!("File rename pattern {pat} likely won't create unique files.");
             }
             self.rename_file = Some(pat);
         }

--- a/id3tag/src/default_values.rs
+++ b/id3tag/src/default_values.rs
@@ -245,7 +245,7 @@ impl DefaultValues {
         let mut config_toml = String::new();
 
         let mut file =
-            File::open(filename).with_context(|| format!("Config file {filename} not found"))?;
+            File::open(filename).with_context(|| format!("Failed to open config file {filename}"))?;
 
         let bytes = file.read_to_string(&mut config_toml)?;
         if bytes == 0 {

--- a/id3tag/src/formats/ape.rs
+++ b/id3tag/src/formats/ape.rs
@@ -41,7 +41,7 @@ pub fn process(
                     Err(err) => {
                         if config.execution.stop_on_error.unwrap_or(true) {
                             return Err(err)
-                                .context(format!("Unable to set {ape_key} to {value}"));
+                                .with_context(|| format!("Unable to set {ape_key} to {value}"));
                         }
                         log::error!("Unable to set {ape_key} to {value}. Continuing: {err:#}");
                     }
@@ -60,7 +60,7 @@ pub fn process(
                     }
                     Err(err) => {
                         if config.execution.stop_on_error.unwrap_or(true) {
-                            return Err(err).context(format!("Unable to set {key} to {value}"));
+                            return Err(err).with_context(|| format!("Unable to set {key} to {value}"));
                         }
                         log::error!("Unable to set {key} to {value}: {err:#}");
                     }

--- a/id3tag/src/formats/ape.rs
+++ b/id3tag/src/formats/ape.rs
@@ -4,14 +4,15 @@
 use crate::default_values::DefaultValues;
 use crate::formats::images::read_cover;
 use ape::{self, Item, ItemType};
-use std::{collections::HashMap, error::Error, fs::File};
+use anyhow::{bail, Result};
+use std::{collections::HashMap, fs::File};
 
 /// Performs the actual processing of APE files.
 pub fn process(
     filename: &str,
     new_tags: &HashMap<String, String>,
     config: &DefaultValues,
-) -> Result<bool, Box<dyn Error>> {
+) -> Result<bool> {
     let mut processed_ok = false;
     let mut tags = ape::read_from_path(filename)?;
 
@@ -39,10 +40,7 @@ pub fn process(
                     Ok(()) => log::debug!("{ape_key} set for {filename}."),
                     Err(err) => {
                         if config.execution.stop_on_error.unwrap_or(true) {
-                            return Err(format!(
-                                "Unable to set {ape_key} to {value}. Error: {err}"
-                            )
-                            .into());
+                            bail!("Unable to set {ape_key} to {value}. Error: {err}");
                         }
                         log::error!("Unable to set {ape_key} to {value}. Continuing. Error: {err}");
                     }
@@ -61,10 +59,7 @@ pub fn process(
                     }
                     Err(err) => {
                         if config.execution.stop_on_error.unwrap_or(true) {
-                            return Err(format!(
-                                "Unable to set {key} to {value}. Error message: {err}"
-                            )
-                            .into());
+                            bail!("Unable to set {key} to {value}. Error message: {err}");
                         }
                         log::error!("Unable to set {key} to {value}. Error message: {err}");
                     }
@@ -104,7 +99,7 @@ fn set_picture(
     img_file: &str,
     ape_key: &str,
     max_size: u32,
-) -> Result<(), Box<dyn Error>> {
+) -> Result<()> {
     // Remove existing cover art with this key
     let _ = tags.remove_items(ape_key);
 
@@ -132,7 +127,7 @@ fn rename_file(
     _filename: &str,
     _config: &DefaultValues,
     _tags: &ape::Tag,
-) -> Result<(), Box<dyn Error>> {
+) -> Result<()> {
     log::warn!(
         "Rename is currently not supported for APE files because the metadata is not standardized."
     );

--- a/id3tag/src/formats/ape.rs
+++ b/id3tag/src/formats/ape.rs
@@ -3,8 +3,8 @@
 
 use crate::default_values::DefaultValues;
 use crate::formats::images::read_cover;
-use ape::{self, Item, ItemType};
 use anyhow::{bail, Result};
+use ape::{self, Item, ItemType};
 use std::{collections::HashMap, fs::File};
 
 /// Performs the actual processing of APE files.
@@ -94,12 +94,7 @@ pub fn process(
 /// Sets the front or back cover art in an APE tag.
 /// APE cover art convention: key is "Cover Art (Front)" or "Cover Art (Back)",
 /// value is a binary item with format: `description\0` + raw image bytes.
-fn set_picture(
-    tags: &mut ape::Tag,
-    img_file: &str,
-    ape_key: &str,
-    max_size: u32,
-) -> Result<()> {
+fn set_picture(tags: &mut ape::Tag, img_file: &str, ape_key: &str, max_size: u32) -> Result<()> {
     // Remove existing cover art with this key
     let _ = tags.remove_items(ape_key);
 
@@ -123,11 +118,7 @@ fn set_picture(
 /// Renames the APE file based on the tags
 // Allow the uneccesary Ok(()) for now for consistency with other functions and possible changes later.
 #[allow(clippy::unnecessary_wraps)]
-fn rename_file(
-    _filename: &str,
-    _config: &DefaultValues,
-    _tags: &ape::Tag,
-) -> Result<()> {
+fn rename_file(_filename: &str, _config: &DefaultValues, _tags: &ape::Tag) -> Result<()> {
     log::warn!(
         "Rename is currently not supported for APE files because the metadata is not standardized."
     );

--- a/id3tag/src/formats/ape.rs
+++ b/id3tag/src/formats/ape.rs
@@ -3,7 +3,7 @@
 
 use crate::default_values::DefaultValues;
 use crate::formats::images::read_cover;
-use anyhow::{bail, Result};
+use anyhow::{Context, Result};
 use ape::{self, Item, ItemType};
 use std::{collections::HashMap, fs::File};
 
@@ -40,9 +40,10 @@ pub fn process(
                     Ok(()) => log::debug!("{ape_key} set for {filename}."),
                     Err(err) => {
                         if config.execution.stop_on_error.unwrap_or(true) {
-                            bail!("Unable to set {ape_key} to {value}. Error: {err}");
+                            return Err(err)
+                                .context(format!("Unable to set {ape_key} to {value}"));
                         }
-                        log::error!("Unable to set {ape_key} to {value}. Continuing. Error: {err}");
+                        log::error!("Unable to set {ape_key} to {value}. Continuing: {err:#}");
                     }
                 }
             }
@@ -59,9 +60,9 @@ pub fn process(
                     }
                     Err(err) => {
                         if config.execution.stop_on_error.unwrap_or(true) {
-                            bail!("Unable to set {key} to {value}. Error message: {err}");
+                            return Err(err).context(format!("Unable to set {key} to {value}"));
                         }
-                        log::error!("Unable to set {key} to {value}. Error message: {err}");
+                        log::error!("Unable to set {key} to {value}: {err:#}");
                     }
                 }
             }

--- a/id3tag/src/formats/dsf.rs
+++ b/id3tag/src/formats/dsf.rs
@@ -167,7 +167,7 @@ fn rename_file(filename: &str, config: &DefaultValues, tag: &id3::Tag) -> Result
         Err(err) => {
             if config.execution.stop_on_error.unwrap_or(false) {
                 return Err(err)
-                    .context(format!("Unable to rename {filename} with tags \"{pattern}\""));
+                    .with_context(|| format!("Unable to rename {filename} with tags \"{pattern}\""));
             }
             log::warn!(
                 "Unable to rename {filename} with tags \"{pattern}\": {err:#} Continuing.",
@@ -198,7 +198,7 @@ fn to_number(value: &str, item: &str, stop_on_error: bool) -> Result<u32> {
         Ok(n) => n,
         Err(err) => {
             if stop_on_error {
-                return Err(err).context(format!("Unable to set {item} to {value}"));
+                return Err(err).with_context(|| format!("Unable to set {item} to {value}"));
             }
             log::error!(
                 "Unable to set {item} to {value}. Setting to 1 and continuing: {err:#}",

--- a/id3tag/src/formats/dsf.rs
+++ b/id3tag/src/formats/dsf.rs
@@ -6,14 +6,15 @@ use crate::rename_file;
 use common::FileTypes;
 use dsf::{self, DsfFile};
 use id3::TagLike;
-use std::{collections::HashMap, error::Error, path::Path};
+use anyhow::{bail, Result};
+use std::{collections::HashMap, path::Path};
 
 /// Performs the actual processing of DSF files.
 pub fn process(
     filename: &str,
     new_tags: &HashMap<String, String>,
     config: &DefaultValues,
-) -> Result<bool, Box<dyn Error>> {
+) -> Result<bool> {
     log::debug!("Filename: {filename}");
 
     let mut processed_ok = false;
@@ -110,7 +111,7 @@ fn rename_file(
     filename: &str,
     config: &DefaultValues,
     tag: &id3::Tag,
-) -> Result<(), Box<dyn Error>> {
+) -> Result<()> {
     let tags_names = option_to_tag(FileTypes::Dsf);
     let mut replace_map = HashMap::new();
 
@@ -151,10 +152,7 @@ fn rename_file(
                         replace_map.insert("%track-number-total".to_string(), total);
                     }
                     _ => {
-                        return Err(format!(
-                            "Unknown tag {tag_name} encountered when unwrapping disc/track information."
-                        )
-                        .into())
+                        bail!("Unknown tag {tag_name} encountered when unwrapping disc/track information.")
                     }
                 }
             } else {
@@ -172,10 +170,7 @@ fn rename_file(
         Ok(new_filename) => log::info!("{filename} --> {new_filename}"),
         Err(err) => {
             if config.execution.stop_on_error.unwrap_or(false) {
-                return Err(format!(
-                    "Unable to rename {filename} with tags \"{pattern}\". Error: {err}"
-                )
-                .into());
+                bail!("Unable to rename {filename} with tags \"{pattern}\". Error: {err}");
             }
             log::warn!(
                 "Unable to rename {filename} with tags \"{pattern}\". Error: {err} Continuing.",
@@ -201,12 +196,12 @@ fn rename_file(
 ///
 /// # Errors
 ///     If the value is not a number, return an error
-fn to_number(value: &str, item: &str, stop_on_error: bool) -> Result<u32, Box<dyn Error>> {
+fn to_number(value: &str, item: &str, stop_on_error: bool) -> Result<u32> {
     let num = match value.parse::<u32>() {
         Ok(n) => n,
         Err(err) => {
             if stop_on_error {
-                return Err(format!("Unable to set {item} to {value}. Error: {err}").into());
+                bail!("Unable to set {item} to {value}. Error: {err}");
             }
             log::error!(
                 "Unable to set {item} to {value}. Setting to 1 and continuing. Error: {err}",

--- a/id3tag/src/formats/dsf.rs
+++ b/id3tag/src/formats/dsf.rs
@@ -3,10 +3,10 @@
 use crate::default_values::DefaultValues;
 use crate::formats::tags::option_to_tag;
 use crate::rename_file;
+use anyhow::{bail, Result};
 use common::FileTypes;
 use dsf::{self, DsfFile};
 use id3::TagLike;
-use anyhow::{bail, Result};
 use std::{collections::HashMap, path::Path};
 
 /// Performs the actual processing of DSF files.
@@ -107,11 +107,7 @@ pub fn process(
 }
 
 /// Renames an MP3 file based on the pattern provided
-fn rename_file(
-    filename: &str,
-    config: &DefaultValues,
-    tag: &id3::Tag,
-) -> Result<()> {
+fn rename_file(filename: &str, config: &DefaultValues, tag: &id3::Tag) -> Result<()> {
     let tags_names = option_to_tag(FileTypes::Dsf);
     let mut replace_map = HashMap::new();
 

--- a/id3tag/src/formats/dsf.rs
+++ b/id3tag/src/formats/dsf.rs
@@ -3,7 +3,7 @@
 use crate::default_values::DefaultValues;
 use crate::formats::tags::option_to_tag;
 use crate::rename_file;
-use anyhow::{bail, Result};
+use anyhow::{bail, Context, Result};
 use common::FileTypes;
 use dsf::{self, DsfFile};
 use id3::TagLike;
@@ -166,10 +166,11 @@ fn rename_file(filename: &str, config: &DefaultValues, tag: &id3::Tag) -> Result
         Ok(new_filename) => log::info!("{filename} --> {new_filename}"),
         Err(err) => {
             if config.execution.stop_on_error.unwrap_or(false) {
-                bail!("Unable to rename {filename} with tags \"{pattern}\". Error: {err}");
+                return Err(err)
+                    .context(format!("Unable to rename {filename} with tags \"{pattern}\""));
             }
             log::warn!(
-                "Unable to rename {filename} with tags \"{pattern}\". Error: {err} Continuing.",
+                "Unable to rename {filename} with tags \"{pattern}\": {err:#} Continuing.",
             );
         }
     }
@@ -197,10 +198,10 @@ fn to_number(value: &str, item: &str, stop_on_error: bool) -> Result<u32> {
         Ok(n) => n,
         Err(err) => {
             if stop_on_error {
-                bail!("Unable to set {item} to {value}. Error: {err}");
+                return Err(err).context(format!("Unable to set {item} to {value}"));
             }
             log::error!(
-                "Unable to set {item} to {value}. Setting to 1 and continuing. Error: {err}",
+                "Unable to set {item} to {value}. Setting to 1 and continuing: {err:#}",
             );
             1
         }

--- a/id3tag/src/formats/flac.rs
+++ b/id3tag/src/formats/flac.rs
@@ -5,7 +5,7 @@ use crate::formats::images::read_cover;
 use crate::formats::tags;
 use crate::formats::FileTypes;
 use crate::rename_file;
-use anyhow::{bail, Result};
+use anyhow::{Context, Result};
 use metaflac::block::PictureType::{CoverBack, CoverFront};
 use metaflac::Tag;
 use std::collections::HashMap;
@@ -107,10 +107,11 @@ pub fn process(
                     Ok(()) => log::debug!("process::{cover_type:?} set."),
                     Err(err) => {
                         if cfg.execution.stop_on_error.unwrap_or(true) {
-                            bail!("Unable to set {cover_type:?} to {v}. Error message: {err}");
+                            return Err(err)
+                                .context(format!("Unable to set {cover_type:?} to {v}"));
                         }
                         log::error!(
-                            "Unable to set {cover_type:?} to {v}. Continuing. Error message: {err}"
+                            "Unable to set {cover_type:?} to {v}. Continuing: {err:#}"
                         );
                     }
                 } // match
@@ -124,14 +125,19 @@ pub fn process(
     if cfg.execution.dry_run.unwrap_or(true) {
         log::debug!("Dry-run. Not saving.");
         processed_ok = true;
-    } else if tags.save().is_ok() {
-        processed_ok = true;
-        log::info!("{m_file}   ✓");
     } else {
-        if cfg.execution.stop_on_error.unwrap_or(true) {
-            bail!("Unable to save {m_file}");
+        match tags.save() {
+            Ok(()) => {
+                processed_ok = true;
+                log::info!("{m_file}   ✓");
+            }
+            Err(err) => {
+                if cfg.execution.stop_on_error.unwrap_or(true) {
+                    return Err(err).context(format!("Unable to save {m_file}"));
+                }
+                log::warn!("Unable to save {m_file}: {err:#}");
+            }
         }
-        log::warn!("Unable to save {m_file}");
     }
 
     // Rename file
@@ -189,10 +195,11 @@ fn rename_file(filename: &str, config: &DefaultValues, tags: &metaflac::Tag) -> 
         Ok(new_filename) => log::info!("{filename} --> {new_filename}"),
         Err(err) => {
             if config.execution.stop_on_error.unwrap_or(true) {
-                bail!("Unable to rename {filename} with tags \"{pattern}\". Error: {err}");
+                return Err(err)
+                    .context(format!("Unable to rename {filename} with tags \"{pattern}\""));
             }
             log::warn!(
-                "Unable to rename {filename} with tags \"{pattern}\". Error: {err} Continuing."
+                "Unable to rename {filename} with tags \"{pattern}\": {err:#} Continuing."
             );
         }
     }

--- a/id3tag/src/formats/flac.rs
+++ b/id3tag/src/formats/flac.rs
@@ -108,7 +108,7 @@ pub fn process(
                     Err(err) => {
                         if cfg.execution.stop_on_error.unwrap_or(true) {
                             return Err(err)
-                                .context(format!("Unable to set {cover_type:?} to {v}"));
+                                .with_context(|| format!("Unable to set {cover_type:?} to {v}"));
                         }
                         log::error!(
                             "Unable to set {cover_type:?} to {v}. Continuing: {err:#}"
@@ -133,7 +133,7 @@ pub fn process(
             }
             Err(err) => {
                 if cfg.execution.stop_on_error.unwrap_or(true) {
-                    return Err(err).context(format!("Unable to save {m_file}"));
+                    return Err(err).with_context(|| format!("Unable to save {m_file}"));
                 }
                 log::warn!("Unable to save {m_file}: {err:#}");
             }
@@ -196,7 +196,7 @@ fn rename_file(filename: &str, config: &DefaultValues, tags: &metaflac::Tag) -> 
         Err(err) => {
             if config.execution.stop_on_error.unwrap_or(true) {
                 return Err(err)
-                    .context(format!("Unable to rename {filename} with tags \"{pattern}\""));
+                    .with_context(|| format!("Unable to rename {filename} with tags \"{pattern}\""));
             }
             log::warn!(
                 "Unable to rename {filename} with tags \"{pattern}\": {err:#} Continuing."

--- a/id3tag/src/formats/flac.rs
+++ b/id3tag/src/formats/flac.rs
@@ -5,9 +5,9 @@ use crate::formats::images::read_cover;
 use crate::formats::tags;
 use crate::formats::FileTypes;
 use crate::rename_file;
+use anyhow::{bail, Result};
 use metaflac::block::PictureType::{CoverBack, CoverFront};
 use metaflac::Tag;
-use anyhow::{bail, Result};
 use std::collections::HashMap;
 
 /// Splits the incoming value into two the (disc/track) number and count.
@@ -161,11 +161,7 @@ fn set_picture(
 }
 
 /// Renames a FLAC file based on the pattern provided
-fn rename_file(
-    filename: &str,
-    config: &DefaultValues,
-    tags: &metaflac::Tag,
-) -> Result<()> {
+fn rename_file(filename: &str, config: &DefaultValues, tags: &metaflac::Tag) -> Result<()> {
     let tags_names = tags::option_to_tag(FileTypes::Flac);
     let mut replace_map = HashMap::new();
     let mut pattern = String::new();

--- a/id3tag/src/formats/flac.rs
+++ b/id3tag/src/formats/flac.rs
@@ -52,7 +52,10 @@ macro_rules! split {
 ///
 /// **Returns:**
 ///
-/// `anyhow::Result<bool>` -- `Ok(true)` if the file was processed, otherwise an error.
+/// `anyhow::Result<bool>` -- `Ok(true)` if the file was saved successfully or a dry-run was
+/// performed; `Ok(false)` if saving failed but `stop_on_error` is disabled (a warning is logged
+/// and processing continues); `Err(...)` if saving failed and `stop_on_error` is enabled, or if
+/// any other unrecoverable error occurred.
 ///
 /// **Example:**
 ///

--- a/id3tag/src/formats/flac.rs
+++ b/id3tag/src/formats/flac.rs
@@ -7,8 +7,8 @@ use crate::formats::FileTypes;
 use crate::rename_file;
 use metaflac::block::PictureType::{CoverBack, CoverFront};
 use metaflac::Tag;
+use anyhow::{bail, Result};
 use std::collections::HashMap;
-use std::error::Error;
 
 /// Splits the incoming value into two the (disc/track) number and count.
 /// Inserts the split values into their respective spots in the `HashSet`.
@@ -52,7 +52,7 @@ macro_rules! split {
 ///
 /// **Returns:**
 ///
-/// `Result<(), Box<dyn Error>>` -- Nothing except `Ok` if things go well, otherwise an error.
+/// `anyhow::Result<bool>` -- `Ok(true)` if the file was processed, otherwise an error.
 ///
 /// **Example:**
 ///
@@ -61,7 +61,7 @@ pub fn process(
     m_file: &str,
     nt: &mut HashMap<String, String>,
     config: &DefaultValues,
-) -> Result<bool, Box<dyn Error>> {
+) -> Result<bool> {
     let mut tags = Tag::read_from_path(m_file)?;
     let mut processed_ok = false;
     let mut cfg = config.clone();
@@ -104,10 +104,7 @@ pub fn process(
                     Ok(()) => log::debug!("process::{cover_type:?} set."),
                     Err(err) => {
                         if cfg.execution.stop_on_error.unwrap_or(true) {
-                            return Err(format!(
-                                "Unable to set {cover_type:?} to {v}. Error message: {err}"
-                            )
-                            .into());
+                            bail!("Unable to set {cover_type:?} to {v}. Error message: {err}");
                         }
                         log::error!(
                             "Unable to set {cover_type:?} to {v}. Continuing. Error message: {err}"
@@ -129,7 +126,7 @@ pub fn process(
         log::info!("{m_file}   ✓");
     } else {
         if cfg.execution.stop_on_error.unwrap_or(true) {
-            return Err(format!("Unable to save {m_file}").into());
+            bail!("Unable to save {m_file}");
         }
         log::warn!("Unable to save {m_file}");
     }
@@ -149,7 +146,7 @@ fn set_picture(
     img_file: &str,
     cover_type: metaflac::block::PictureType,
     max_size: u32,
-) -> Result<(), Box<dyn Error>> {
+) -> Result<()> {
     tags.remove_picture_type(cover_type);
     let (img, mime_type) = read_cover(img_file, max_size)?;
     log::debug!(
@@ -168,7 +165,7 @@ fn rename_file(
     filename: &str,
     config: &DefaultValues,
     tags: &metaflac::Tag,
-) -> Result<(), Box<dyn Error>> {
+) -> Result<()> {
     let tags_names = tags::option_to_tag(FileTypes::Flac);
     let mut replace_map = HashMap::new();
     let mut pattern = String::new();
@@ -193,10 +190,7 @@ fn rename_file(
         Ok(new_filename) => log::info!("{filename} --> {new_filename}"),
         Err(err) => {
             if config.execution.stop_on_error.unwrap_or(true) {
-                return Err(format!(
-                    "Unable to rename {filename} with tags \"{pattern}\". Error: {err}"
-                )
-                .into());
+                bail!("Unable to rename {filename} with tags \"{pattern}\". Error: {err}");
             }
             log::warn!(
                 "Unable to rename {filename} with tags \"{pattern}\". Error: {err} Continuing."

--- a/id3tag/src/formats/images/mod.rs
+++ b/id3tag/src/formats/images/mod.rs
@@ -1,7 +1,7 @@
 //! Image processing module. Contains functions for finding and reading cover images.
 
+use anyhow::{bail, Result};
 use image::{self, imageops::FilterType, ImageFormat, ImageReader};
-use std::error::Error;
 use std::io::Cursor;
 use std::path::Path;
 
@@ -29,11 +29,11 @@ pub use ops::aspect_ratio_ok;
 ///
 /// # Returns
 ///
-/// `Result<(Option<String>, Option<String>), Box<dyn Error>>` - an `Option<String>` tuple containing the paths to the front and back covers, or None, if nothing has been found.
+/// `anyhow::Result<(Option<String>, Option<String>)>` - an `Option<String>` tuple containing the paths to the front and back covers, or None, if nothing has been found.
 pub fn get_cover_filenames(
     music_file: &str,
     cfg: &DefaultValues,
-) -> Result<(Option<String>, Option<String>), Box<dyn Error>> {
+) -> Result<(Option<String>, Option<String>)> {
     let front_cover_path = if cfg.pictures.picture_front_candidates.is_some() {
         find_cover(CoverType::Front, music_file, cfg)?
     } else {
@@ -61,13 +61,13 @@ pub fn get_cover_filenames(
 ///
 /// # Returns:
 ///
-/// `Result<String, Box<dyn Error>>` - returns a string with the path to the cover if found, or an empty string if not.
+/// `anyhow::Result<Option<String>>` - returns a string with the path to the cover if found, or `None` if not.
 /// Returns an error if something goes wrong
 fn find_cover(
     cover_type: CoverType,
     music_file: &str,
     cfg: &DefaultValues,
-) -> Result<Option<String>, Box<dyn Error>> {
+) -> Result<Option<String>> {
     let cover_candidates = gather_cover_candidates(cover_type, cfg);
 
     let cover_path = find_first_image(music_file, &cover_candidates)?;
@@ -95,17 +95,15 @@ fn find_cover(
 ///
 /// Returns an error if the image cannot be read or if the aspect ratio is not within the expected range.
 /// The expected aspect ratio is within 1.5:1 and 1:1.5 (eg. 300x200, 200x300, 300x300, 200x200)
-pub fn read_cover(cover_file: &str, max_size: u32) -> Result<(Vec<u8>, String), Box<dyn Error>> {
+pub fn read_cover(cover_file: &str, max_size: u32) -> Result<(Vec<u8>, String)> {
     let img = ImageReader::open(cover_file)?.decode()?;
 
     if !aspect_ratio_ok(img.width(), img.height()) {
-        return Err(format!("Image {cover_file} is outside the expected ratio.").into());
+        bail!("Image {cover_file} is outside the expected ratio.");
     }
 
     if image_too_small(&img, max_size) {
-        return Err(
-            format!("Image {cover_file} is too small. (Less than 1/2 the cover size.)").into(),
-        );
+        bail!("Image {cover_file} is too small. (Less than 1/2 the cover size.)");
     }
 
     let output_format = detect_format(cover_file);
@@ -123,7 +121,7 @@ pub fn read_cover(cover_file: &str, max_size: u32) -> Result<(Vec<u8>, String), 
 }
 
 /// Converts image bytes to JPEG format. Used by formats that only support JPEG (e.g. MP4).
-pub fn to_jpeg(data: &[u8]) -> Result<Vec<u8>, Box<dyn Error>> {
+pub fn to_jpeg(data: &[u8]) -> Result<Vec<u8>> {
     let img = image::load_from_memory(data)?;
     let mut buf: Cursor<Vec<u8>> = Cursor::new(Vec::new());
     img.write_to(&mut buf, ImageFormat::Jpeg)?;

--- a/id3tag/src/formats/images/mod.rs
+++ b/id3tag/src/formats/images/mod.rs
@@ -89,7 +89,7 @@ fn find_cover(
 ///
 /// # Returns
 ///
-/// `Result<(Vec<u8>, String), Box<dyn Error>>` - a tuple of image bytes and mime type string.
+/// `anyhow::Result<(Vec<u8>, String)>` - a tuple of image bytes and mime type string.
 ///
 /// # Errors
 ///

--- a/id3tag/src/formats/images/mod.rs
+++ b/id3tag/src/formats/images/mod.rs
@@ -61,8 +61,8 @@ pub fn get_cover_filenames(
 ///
 /// # Returns:
 ///
-/// `anyhow::Result<Option<String>>` - returns a string with the path to the cover if found, or `None` if not.
-/// Returns an error if something goes wrong
+/// `anyhow::Result<Option<String>>` - `Some(path)` if a cover file was found, `None` if no cover
+/// was found, or an error if something goes wrong (e.g. the music file path is invalid).
 fn find_cover(
     cover_type: CoverType,
     music_file: &str,

--- a/id3tag/src/formats/images/paths.rs
+++ b/id3tag/src/formats/images/paths.rs
@@ -81,7 +81,7 @@ pub fn gather_cover_candidates(cover_type: CoverType, cfg: &DefaultValues) -> Ve
 /// # Arguments
 ///
 /// `music_file: &str` - the name (and full path) of the music file being used as the basis for the search.
-/// `image_vec: &Vec<String>` - a vector of string values containing the candidate filenames to be searched.
+/// `image_vec: &[String]` - a slice of candidate filenames to be searched.
 ///
 /// # Returns
 ///

--- a/id3tag/src/formats/images/paths.rs
+++ b/id3tag/src/formats/images/paths.rs
@@ -93,10 +93,7 @@ pub fn gather_cover_candidates(cover_type: CoverType, cfg: &DefaultValues) -> Ve
 /// - Returns an error if the music directory cannot be canonicalized.
 /// - Returns an error if the music file's directory cannot be determined.
 /// - Returns an error if the image path cannot be canonicalized.
-pub fn find_first_image(
-    m_file: &str,
-    image_vec: &Vec<String>,
-) -> Result<Option<PathBuf>> {
+pub fn find_first_image(m_file: &str, image_vec: &Vec<String>) -> Result<Option<PathBuf>> {
     let music_file = Path::new(m_file);
     if !music_file.exists() {
         bail!("Music file {m_file} does not appear to exist.");

--- a/id3tag/src/formats/images/paths.rs
+++ b/id3tag/src/formats/images/paths.rs
@@ -93,7 +93,7 @@ pub fn gather_cover_candidates(cover_type: CoverType, cfg: &DefaultValues) -> Ve
 /// - Returns an error if the music directory cannot be canonicalized.
 /// - Returns an error if the music file's directory cannot be determined.
 /// - Returns an error if the image path cannot be canonicalized.
-pub fn find_first_image(m_file: &str, image_vec: &Vec<String>) -> Result<Option<PathBuf>> {
+pub fn find_first_image(m_file: &str, image_vec: &[String]) -> Result<Option<PathBuf>> {
     let music_file = Path::new(m_file);
     if !music_file.exists() {
         bail!("Music file {m_file} does not appear to exist.");

--- a/id3tag/src/formats/images/paths.rs
+++ b/id3tag/src/formats/images/paths.rs
@@ -1,6 +1,6 @@
 //! Image path related functions
 
-use std::error::Error;
+use anyhow::{bail, Result};
 use std::path::{Path, PathBuf};
 
 use common::directory;
@@ -51,7 +51,7 @@ pub fn complete_path(folder: &Path, filename: &String) -> String {
 /// `cfg: &DefaultValues` - program configuration as surmised from the CLI and config file
 ///
 /// Returns:
-/// `Result<Vec<String>, Box<dyn Error>>`: A vector of strings containing the paths to be searched, or an error if something goes wrong.
+/// `Vec<String>`: A vector of strings containing the paths to be searched.
 pub fn gather_cover_candidates(cover_type: CoverType, cfg: &DefaultValues) -> Vec<String> {
     let search_folders = cfg.pictures.search_folders();
     log::debug!("gather_cover_candidates::search_folders = {search_folders:?}");
@@ -85,7 +85,7 @@ pub fn gather_cover_candidates(cover_type: CoverType, cfg: &DefaultValues) -> Ve
 ///
 /// # Returns
 ///
-/// `Result<Option<PathBuf>, Box<dyn Error>>` - the full path of the first image found, or `Ok(None)` if nothing is found.
+/// `anyhow::Result<Option<PathBuf>>` - the full path of the first image found, or `Ok(None)` if nothing is found.
 ///
 /// # Errors
 ///
@@ -96,10 +96,10 @@ pub fn gather_cover_candidates(cover_type: CoverType, cfg: &DefaultValues) -> Ve
 pub fn find_first_image(
     m_file: &str,
     image_vec: &Vec<String>,
-) -> Result<Option<PathBuf>, Box<dyn Error>> {
+) -> Result<Option<PathBuf>> {
     let music_file = Path::new(m_file);
     if !music_file.exists() {
-        return Err(format!("Music file {m_file} does not appear to exist.").into());
+        bail!("Music file {m_file} does not appear to exist.");
     }
 
     let music_path = music_file.canonicalize()?;

--- a/id3tag/src/formats/mod.rs
+++ b/id3tag/src/formats/mod.rs
@@ -2,9 +2,9 @@
 //! all reside under this crate, so they don't have to be exposed to the main body of code.
 
 #![forbid(unsafe_code)]
+use anyhow::{bail, Result};
 use std::{
     collections::HashMap,
-    error::Error,
     fs,
     path::{Component, Path},
 };
@@ -37,13 +37,13 @@ use crate::{disc_number_count, pic, tag, track_album_artist, track_genre_num, tr
 /// Returns:
 ///
 /// - `Ok(bool)` if everything goes well. The boolean indicates whether the file was processed or not.
-/// - `Box<dyn Error>` if we run into problems
+/// - `anyhow::Error` if we run into problems
 pub fn process_file(
     file_type: FileTypes,
     filename: &str,
     cfg: &DefaultValues,
     cli_args: &clap::ArgMatches,
-) -> Result<bool, Box<dyn Error>> {
+) -> Result<bool> {
     // Check if we need to create one or more cover images.
     log::debug!("process_file::filename = {filename}");
     let mut config = cfg.clone();
@@ -74,7 +74,7 @@ pub fn process_file(
                 FileTypes::MP3 => mp3::process(filename, &new_tags, &config),
                 FileTypes::M4A => mp4::process(filename, &new_tags, &config),
                 FileTypes::Unknown => {
-                    return Err(format!("{filename} is unknown file type.").into())
+                    bail!("{filename} is unknown file type.")
                 }
             };
 
@@ -82,7 +82,7 @@ pub fn process_file(
                 Ok(_) => processed = true,
                 Err(err) => {
                     if config.execution.stop_on_error.unwrap_or(true) {
-                        return Err(format!("Unable to process {filename}. Error: {err}").into());
+                        bail!("Unable to process {filename}. Error: {err}");
                     }
                     log::error!("Unable to process {filename}. Error: {err}");
                 }
@@ -90,7 +90,7 @@ pub fn process_file(
         } // Ok(_)
         Err(err) => {
             if config.execution.stop_on_error.unwrap_or(true) {
-                return Err(format!("Unable to parse tags for {filename}. Error: {err}").into());
+                bail!("Unable to parse tags for {filename}. Error: {err}");
             }
             log::error!("Unable to parse tags for {filename}. Error: {err}");
         } // Err(err)
@@ -109,7 +109,7 @@ fn parse_options(
     file_type: common::FileTypes,
     dv: &DefaultValues,
     cli: &clap::ArgMatches,
-) -> Result<HashMap<String, String>, Box<dyn Error>> {
+) -> Result<HashMap<String, String>> {
     let mut nt = HashMap::new();
     let ot = tags::get_tag_names(file_type);
 
@@ -214,9 +214,9 @@ fn parse_options(
 /// Convert a numerical ID3 genre to a string
 /// Ref: <https://en.wikipedia.org/wiki/ID3#Genre_list_in_ID3v1%5B12%5D>
 #[allow(clippy::too_many_lines)] // Not much we can do about this one.
-fn genre_name(tagnumber: u16) -> Result<String, Box<dyn Error>> {
+fn genre_name(tagnumber: u16) -> Result<String> {
     if tagnumber > 191 {
-        return Err("Incorrect value supplied. Must be 0-191.".into());
+        bail!("Incorrect value supplied. Must be 0-191.");
     }
 
     let tags = vec![
@@ -421,7 +421,7 @@ fn genre_name(tagnumber: u16) -> Result<String, Box<dyn Error>> {
 /// It it is named 'CD xx' or 'disc xx' (case insensitive), we get the number and use it.
 // TODO: There may be a better way to do this by tokenizing the filename.
 // TODO: Need to be able to handle cases like CD1of3 ("CD1 of 3" is fine)
-fn disc_number(filename: &str) -> Result<u16, Box<dyn Error>> {
+fn disc_number(filename: &str) -> Result<u16> {
     let mut parent_dir = common::directory(filename)?
         .file_name()
         .unwrap_or_default()
@@ -498,21 +498,19 @@ fn disc_number(filename: &str) -> Result<u16, Box<dyn Error>> {
 ///
 /// # Returns
 ///
-/// * `Result<u16, Box<dyn Error>>` - The number of discs as a `u16` if successful, otherwise an error.
+/// * `anyhow::Result<u16>` - The number of discs as a `u16` if successful, otherwise an error.
 ///
 /// # Examples
 ///
 /// ```
-/// use std::error::Error;
-///
-/// fn main() -> Result<(), Box<dyn Error>> {
+/// fn main() -> anyhow::Result<()> {
 ///     let filename = "/path/to/file.mp3";
 ///     let disc_count = disc_count(filename)?;
 ///     println!("Number of discs: {disc_count}");
 ///     Ok(())
 /// }
 /// ```
-fn disc_count(filename: &str) -> Result<u16, Box<dyn Error>> {
+fn disc_count(filename: &str) -> Result<u16> {
     let disc_candidates = disc_candidates();
     log::trace!("disc_candidates = {disc_candidates:?}");
 

--- a/id3tag/src/formats/mod.rs
+++ b/id3tag/src/formats/mod.rs
@@ -2,7 +2,7 @@
 //! all reside under this crate, so they don't have to be exposed to the main body of code.
 
 #![forbid(unsafe_code)]
-use anyhow::{bail, Result};
+use anyhow::{bail, Context, Result};
 use std::{
     collections::HashMap,
     fs,
@@ -82,17 +82,17 @@ pub fn process_file(
                 Ok(_) => processed = true,
                 Err(err) => {
                     if config.execution.stop_on_error.unwrap_or(true) {
-                        bail!("Unable to process {filename}. Error: {err}");
+                        return Err(err).context(format!("Unable to process {filename}"));
                     }
-                    log::error!("Unable to process {filename}. Error: {err}");
+                    log::error!("Unable to process {filename}: {err:#}");
                 }
             }
         } // Ok(_)
         Err(err) => {
             if config.execution.stop_on_error.unwrap_or(true) {
-                bail!("Unable to parse tags for {filename}. Error: {err}");
+                return Err(err).context(format!("Unable to parse tags for {filename}"));
             }
-            log::error!("Unable to parse tags for {filename}. Error: {err}");
+            log::error!("Unable to parse tags for {filename}: {err:#}");
         } // Err(err)
     } // match new_tags_result
 

--- a/id3tag/src/formats/mod.rs
+++ b/id3tag/src/formats/mod.rs
@@ -82,7 +82,7 @@ pub fn process_file(
                 Ok(_) => processed = true,
                 Err(err) => {
                     if config.execution.stop_on_error.unwrap_or(true) {
-                        return Err(err).context(format!("Unable to process {filename}"));
+                        return Err(err).with_context(|| format!("Unable to process {filename}"));
                     }
                     log::error!("Unable to process {filename}: {err:#}");
                 }
@@ -90,7 +90,7 @@ pub fn process_file(
         } // Ok(_)
         Err(err) => {
             if config.execution.stop_on_error.unwrap_or(true) {
-                return Err(err).context(format!("Unable to parse tags for {filename}"));
+                return Err(err).with_context(|| format!("Unable to parse tags for {filename}"));
             }
             log::error!("Unable to parse tags for {filename}: {err:#}");
         } // Err(err)

--- a/id3tag/src/formats/mp3.rs
+++ b/id3tag/src/formats/mp3.rs
@@ -7,7 +7,7 @@ use id3::frame::{self, ExtendedText};
 use id3::TagLike;
 use id3::{frame::PictureType, Tag, Version};
 
-use anyhow::{bail, Result};
+use anyhow::{bail, Context, Result};
 use std::collections::HashMap;
 
 /// Performs the actual processing of MP4 files.
@@ -36,9 +36,10 @@ pub fn process(filename: &str, nt: &HashMap<String, String>, cfg: &DefaultValues
                     Ok(()) => (),
                     Err(err) => {
                         if cfg.execution.stop_on_error.unwrap_or(false) {
-                            bail!("Unable to set front cover for {filename}. Error: {err}");
+                            return Err(err)
+                                .context(format!("Unable to set front cover for {filename}"));
                         }
-                        log::error!("Unable to set front cover for {filename}. Error: {err}");
+                        log::error!("Unable to set front cover for {filename}: {err:#}");
                     }
                 }
             }
@@ -49,9 +50,10 @@ pub fn process(filename: &str, nt: &HashMap<String, String>, cfg: &DefaultValues
                 Ok(()) => (),
                 Err(err) => {
                     if cfg.execution.stop_on_error.unwrap_or(false) {
-                        bail!("Unable to set back cover for {filename}. Error: {err}");
+                        return Err(err)
+                            .context(format!("Unable to set back cover for {filename}"));
                     }
-                    log::error!("Unable to set back cover for {filename}. Error: {err}");
+                    log::error!("Unable to set back cover for {filename}: {err:#}");
                 }
             },
 
@@ -64,10 +66,11 @@ pub fn process(filename: &str, nt: &HashMap<String, String>, cfg: &DefaultValues
                     Ok(n) => n,
                     Err(err) => {
                         if cfg.execution.stop_on_error.unwrap_or(false) {
-                            bail!("Unable to set disc number to {value}. Error: {err}");
+                            return Err(err)
+                                .context(format!("Unable to set disc number to {value}"));
                         }
                         log::error!(
-                            "Unable to set disc number to {value}. Setting to 1 and continuing. Error: {err}"
+                            "Unable to set disc number to {value}. Setting to 1 and continuing: {err:#}"
                         );
                         1
                     }
@@ -81,10 +84,12 @@ pub fn process(filename: &str, nt: &HashMap<String, String>, cfg: &DefaultValues
                     Ok(n) => n,
                     Err(err) => {
                         if cfg.execution.stop_on_error.unwrap_or(false) {
-                            bail!("Unable to set total discs to {value}. Error: {err}");
+                            return Err(err)
+                                .context(format!("Unable to set total discs to {value}"));
                         }
                         log::error!(
-                            "Unable to set total discs to {value}. Setting to 1 and continuing. Error: {err}"                        );
+                            "Unable to set total discs to {value}. Setting to 1 and continuing: {err:#}"
+                        );
                         1
                     }
                 };
@@ -97,10 +102,11 @@ pub fn process(filename: &str, nt: &HashMap<String, String>, cfg: &DefaultValues
                     Ok(n) => n,
                     Err(err) => {
                         if cfg.execution.stop_on_error.unwrap_or(false) {
-                            bail!("Unable to set track number to {value}. Error: {err}");
+                            return Err(err)
+                                .context(format!("Unable to set track number to {value}"));
                         }
                         log::error!(
-                            "Unable to set track number to {value}. Setting to 1 and continuing. Error: {err}"
+                            "Unable to set track number to {value}. Setting to 1 and continuing: {err:#}"
                         );
                         1
                     }
@@ -114,10 +120,11 @@ pub fn process(filename: &str, nt: &HashMap<String, String>, cfg: &DefaultValues
                     Ok(n) => n,
                     Err(err) => {
                         if cfg.execution.stop_on_error.unwrap_or(false) {
-                            bail!("Unable to set total tracks to {value}. Error: {err}");
+                            return Err(err)
+                                .context(format!("Unable to set total tracks to {value}"));
                         }
                         log::error!(
-                            "Unable to set total tracks to {value}. Setting to 1 and continuing. Error: {err}"
+                            "Unable to set total tracks to {value}. Setting to 1 and continuing: {err:#}"
                         );
                         1
                     }
@@ -272,10 +279,11 @@ fn rename_file(filename: &str, cfg: &DefaultValues, tag: &id3::Tag) -> Result<()
         Ok(new_filename) => log::info!("{filename} --> {new_filename}"),
         Err(err) => {
             if cfg.execution.stop_on_error.unwrap_or(false) {
-                bail!("Unable to rename {filename} with tags \"{pattern}\". Error: {err}");
+                return Err(err)
+                    .context(format!("Unable to rename {filename} with tags \"{pattern}\""));
             }
             log::warn!(
-                "Unable to rename {filename} with tags \"{pattern}\". Error: {err} Continuing."
+                "Unable to rename {filename} with tags \"{pattern}\": {err:#} Continuing."
             );
         }
     }

--- a/id3tag/src/formats/mp3.rs
+++ b/id3tag/src/formats/mp3.rs
@@ -7,8 +7,8 @@ use id3::frame::{self, ExtendedText};
 use id3::TagLike;
 use id3::{frame::PictureType, Tag, Version};
 
+use anyhow::{bail, Result};
 use std::collections::HashMap;
-use std::error::Error;
 
 /// Performs the actual processing of MP4 files.
 #[allow(clippy::too_many_lines)]
@@ -16,7 +16,7 @@ pub fn process(
     filename: &str,
     nt: &HashMap<String, String>,
     cfg: &DefaultValues,
-) -> Result<bool, Box<dyn Error>> {
+) -> Result<bool> {
     log::debug!("Filename: {filename}");
     let mut processed_ok = false;
     let max_size = cfg.pictures.picture_max_size.unwrap_or(500);
@@ -40,10 +40,7 @@ pub fn process(
                     Ok(()) => (),
                     Err(err) => {
                         if cfg.execution.stop_on_error.unwrap_or(false) {
-                            return Err(format!(
-                                "Unable to set front cover for {filename}. Error: {err}"
-                            )
-                            .into());
+                            bail!("Unable to set front cover for {filename}. Error: {err}");
                         }
                         log::error!("Unable to set front cover for {filename}. Error: {err}");
                     }
@@ -56,10 +53,7 @@ pub fn process(
                 Ok(()) => (),
                 Err(err) => {
                     if cfg.execution.stop_on_error.unwrap_or(false) {
-                        return Err(format!(
-                            "Unable to set back cover for {filename}. Error: {err}"
-                        )
-                        .into());
+                        bail!("Unable to set back cover for {filename}. Error: {err}");
                     }
                     log::error!("Unable to set back cover for {filename}. Error: {err}");
                 }
@@ -74,10 +68,7 @@ pub fn process(
                     Ok(n) => n,
                     Err(err) => {
                         if cfg.execution.stop_on_error.unwrap_or(false) {
-                            return Err(format!(
-                                "Unable to set disc number to {value}. Error: {err}"
-                            )
-                            .into());
+                            bail!("Unable to set disc number to {value}. Error: {err}");
                         }
                         log::error!(
                             "Unable to set disc number to {value}. Setting to 1 and continuing. Error: {err}"
@@ -94,10 +85,7 @@ pub fn process(
                     Ok(n) => n,
                     Err(err) => {
                         if cfg.execution.stop_on_error.unwrap_or(false) {
-                            return Err(format!(
-                                "Unable to set total discs to {value}. Error: {err}"
-                            )
-                            .into());
+                            bail!("Unable to set total discs to {value}. Error: {err}");
                         }
                         log::error!(
                             "Unable to set total discs to {value}. Setting to 1 and continuing. Error: {err}"                        );
@@ -113,10 +101,7 @@ pub fn process(
                     Ok(n) => n,
                     Err(err) => {
                         if cfg.execution.stop_on_error.unwrap_or(false) {
-                            return Err(format!(
-                                "Unable to set track number to {value}. Error: {err}"
-                            )
-                            .into());
+                            bail!("Unable to set track number to {value}. Error: {err}");
                         }
                         log::error!(
                             "Unable to set track number to {value}. Setting to 1 and continuing. Error: {err}"
@@ -133,10 +118,7 @@ pub fn process(
                     Ok(n) => n,
                     Err(err) => {
                         if cfg.execution.stop_on_error.unwrap_or(false) {
-                            return Err(format!(
-                                "Unable to set total tracks to {value}. Error: {err}",
-                            )
-                            .into());
+                            bail!("Unable to set total tracks to {value}. Error: {err}");
                         }
                         log::error!(
                             "Unable to set total tracks to {value}. Setting to 1 and continuing. Error: {err}"
@@ -188,7 +170,7 @@ fn set_picture(
     img_file: &str,
     picture_type: PictureType,
     max_size: u32,
-) -> Result<(), Box<dyn Error>> {
+) -> Result<()> {
     log::debug!("Removing existing picture.");
     tags.remove_picture_by_type(picture_type);
 
@@ -235,7 +217,7 @@ fn set_comment(tags: &mut id3::Tag, value: &str) {
 }
 
 /// Renames an MP3 file based on the pattern provided
-fn rename_file(filename: &str, cfg: &DefaultValues, tag: &id3::Tag) -> Result<(), Box<dyn Error>> {
+fn rename_file(filename: &str, cfg: &DefaultValues, tag: &id3::Tag) -> Result<()> {
     let tags_names = option_to_tag(FileTypes::MP3);
     let mut replace_map = HashMap::new();
 
@@ -276,10 +258,7 @@ fn rename_file(filename: &str, cfg: &DefaultValues, tag: &id3::Tag) -> Result<()
                         replace_map.insert("%track-number-total".to_string(), total);
                     }
                     _ => {
-                        return Err(format!(
-                            "Unknown tag {tag_name} encountered when unwrapping disc/track information."
-                        )
-                        .into())
+                        bail!("Unknown tag {tag_name} encountered when unwrapping disc/track information.")
                     }
                 }
             } else {
@@ -297,10 +276,7 @@ fn rename_file(filename: &str, cfg: &DefaultValues, tag: &id3::Tag) -> Result<()
         Ok(new_filename) => log::info!("{filename} --> {new_filename}"),
         Err(err) => {
             if cfg.execution.stop_on_error.unwrap_or(false) {
-                return Err(format!(
-                    "Unable to rename {filename} with tags \"{pattern}\". Error: {err}"
-                )
-                .into());
+                bail!("Unable to rename {filename} with tags \"{pattern}\". Error: {err}");
             }
             log::warn!(
                 "Unable to rename {filename} with tags \"{pattern}\". Error: {err} Continuing."

--- a/id3tag/src/formats/mp3.rs
+++ b/id3tag/src/formats/mp3.rs
@@ -12,11 +12,7 @@ use std::collections::HashMap;
 
 /// Performs the actual processing of MP4 files.
 #[allow(clippy::too_many_lines)]
-pub fn process(
-    filename: &str,
-    nt: &HashMap<String, String>,
-    cfg: &DefaultValues,
-) -> Result<bool> {
+pub fn process(filename: &str, nt: &HashMap<String, String>, cfg: &DefaultValues) -> Result<bool> {
     log::debug!("Filename: {filename}");
     let mut processed_ok = false;
     let max_size = cfg.pictures.picture_max_size.unwrap_or(500);

--- a/id3tag/src/formats/mp3.rs
+++ b/id3tag/src/formats/mp3.rs
@@ -37,7 +37,7 @@ pub fn process(filename: &str, nt: &HashMap<String, String>, cfg: &DefaultValues
                     Err(err) => {
                         if cfg.execution.stop_on_error.unwrap_or(false) {
                             return Err(err)
-                                .context(format!("Unable to set front cover for {filename}"));
+                                .with_context(|| format!("Unable to set front cover for {filename}"));
                         }
                         log::error!("Unable to set front cover for {filename}: {err:#}");
                     }
@@ -51,7 +51,7 @@ pub fn process(filename: &str, nt: &HashMap<String, String>, cfg: &DefaultValues
                 Err(err) => {
                     if cfg.execution.stop_on_error.unwrap_or(false) {
                         return Err(err)
-                            .context(format!("Unable to set back cover for {filename}"));
+                            .with_context(|| format!("Unable to set back cover for {filename}"));
                     }
                     log::error!("Unable to set back cover for {filename}: {err:#}");
                 }
@@ -67,7 +67,7 @@ pub fn process(filename: &str, nt: &HashMap<String, String>, cfg: &DefaultValues
                     Err(err) => {
                         if cfg.execution.stop_on_error.unwrap_or(false) {
                             return Err(err)
-                                .context(format!("Unable to set disc number to {value}"));
+                                .with_context(|| format!("Unable to set disc number to {value}"));
                         }
                         log::error!(
                             "Unable to set disc number to {value}. Setting to 1 and continuing: {err:#}"
@@ -85,7 +85,7 @@ pub fn process(filename: &str, nt: &HashMap<String, String>, cfg: &DefaultValues
                     Err(err) => {
                         if cfg.execution.stop_on_error.unwrap_or(false) {
                             return Err(err)
-                                .context(format!("Unable to set total discs to {value}"));
+                                .with_context(|| format!("Unable to set total discs to {value}"));
                         }
                         log::error!(
                             "Unable to set total discs to {value}. Setting to 1 and continuing: {err:#}"
@@ -103,7 +103,7 @@ pub fn process(filename: &str, nt: &HashMap<String, String>, cfg: &DefaultValues
                     Err(err) => {
                         if cfg.execution.stop_on_error.unwrap_or(false) {
                             return Err(err)
-                                .context(format!("Unable to set track number to {value}"));
+                                .with_context(|| format!("Unable to set track number to {value}"));
                         }
                         log::error!(
                             "Unable to set track number to {value}. Setting to 1 and continuing: {err:#}"
@@ -121,7 +121,7 @@ pub fn process(filename: &str, nt: &HashMap<String, String>, cfg: &DefaultValues
                     Err(err) => {
                         if cfg.execution.stop_on_error.unwrap_or(false) {
                             return Err(err)
-                                .context(format!("Unable to set total tracks to {value}"));
+                                .with_context(|| format!("Unable to set total tracks to {value}"));
                         }
                         log::error!(
                             "Unable to set total tracks to {value}. Setting to 1 and continuing: {err:#}"
@@ -280,7 +280,7 @@ fn rename_file(filename: &str, cfg: &DefaultValues, tag: &id3::Tag) -> Result<()
         Err(err) => {
             if cfg.execution.stop_on_error.unwrap_or(false) {
                 return Err(err)
-                    .context(format!("Unable to rename {filename} with tags \"{pattern}\""));
+                    .with_context(|| format!("Unable to rename {filename} with tags \"{pattern}\""));
             }
             log::warn!(
                 "Unable to rename {filename} with tags \"{pattern}\": {err:#} Continuing."

--- a/id3tag/src/formats/mp4.rs
+++ b/id3tag/src/formats/mp4.rs
@@ -4,15 +4,15 @@ use crate::default_values::DefaultValues;
 use crate::formats::images;
 use crate::rename_file;
 use mp4ameta::{Data, Fourcc, ImgFmt, Tag};
+use anyhow::{bail, Result};
 use std::collections::HashMap;
-use std::error::Error;
 
 /// Performs the actual processing of MP4 files.
 pub fn process(
     filename: &str,
     new_tags: &HashMap<String, String>,
     config: &DefaultValues,
-) -> Result<bool, Box<dyn Error>> {
+) -> Result<bool> {
     log::debug!("Filename: {}", &filename);
 
     let mut processed_ok = false;
@@ -62,7 +62,7 @@ pub fn process(
             "trkn-t" => tag.set_total_tracks(value.parse::<u16>().unwrap_or(1)),
             _ => {
                 // tag.set_data(Fourcc(key.as_bytes().try_into()?), Data::Utf8(value.into()));
-                return Err(format!("Unknown key: {key}").into());
+                bail!("Unknown key: {key}");
             }
         }
     }
@@ -76,7 +76,7 @@ pub fn process(
             Ok(()) => processed_ok = true,
             Err(err) => {
                 if config.execution.stop_on_error.unwrap_or(true) {
-                    return Err(format!("Unable to save tags to {filename}. Error: {err}").into());
+                    bail!("Unable to save tags to {filename}. Error: {err}");
                 }
                 log::warn!("Unable to save tags to {filename}. Error: {err}");
             }
@@ -89,7 +89,7 @@ pub fn process(
             Ok(()) => processed_ok = true,
             Err(err) => {
                 if config.execution.stop_on_error.unwrap_or(true) {
-                    return Err(format!("Unable to rename {filename}. Error: {err}").into());
+                    bail!("Unable to rename {filename}. Error: {err}");
                 }
                 log::warn!("Unable to rename {filename}. Error: {err}");
             }
@@ -101,7 +101,7 @@ pub fn process(
 }
 
 /// Sets the front or back cover
-fn set_picture(tags: &mut Tag, filename: &str) -> Result<(), Box<dyn Error>> {
+fn set_picture(tags: &mut Tag, filename: &str) -> Result<()> {
     let fmt = ImgFmt::Jpeg;
     let (raw_data, mime_type) = images::read_cover(filename, 0)?;
     // MP4 only supports JPEG — convert if needed
@@ -122,7 +122,7 @@ fn rename_file(
     filename: &str,
     config: &DefaultValues,
     tag: &mp4ameta::Tag,
-) -> Result<(), Box<dyn Error>> {
+) -> Result<()> {
     let tags_map = get_mp4_tags(tag);
     log::debug!("tags_map = {tags_map:?}");
 
@@ -136,10 +136,7 @@ fn rename_file(
         Ok(new_filename) => log::info!("{filename} --> {new_filename}"),
         Err(err) => {
             if config.execution.stop_on_error.unwrap_or(true) {
-                return Err(format!(
-                    "Unable to rename {filename} with tags \"{pattern}\". Error: {err}"
-                )
-                .into());
+                bail!("Unable to rename {filename} with tags \"{pattern}\". Error: {err}");
             }
             log::warn!(
                 "Unable to rename {filename} with tags \"{pattern}\". Error: {err} Continuing."

--- a/id3tag/src/formats/mp4.rs
+++ b/id3tag/src/formats/mp4.rs
@@ -76,7 +76,7 @@ pub fn process(
             Ok(()) => processed_ok = true,
             Err(err) => {
                 if config.execution.stop_on_error.unwrap_or(true) {
-                    return Err(err).context(format!("Unable to save tags to {filename}"));
+                    return Err(err).with_context(|| format!("Unable to save tags to {filename}"));
                 }
                 log::warn!("Unable to save tags to {filename}: {err:#}");
             }
@@ -89,7 +89,7 @@ pub fn process(
             Ok(()) => processed_ok = true,
             Err(err) => {
                 if config.execution.stop_on_error.unwrap_or(true) {
-                    return Err(err).context(format!("Unable to rename {filename}"));
+                    return Err(err).with_context(|| format!("Unable to rename {filename}"));
                 }
                 log::warn!("Unable to rename {filename}: {err:#}");
             }
@@ -133,7 +133,7 @@ fn rename_file(filename: &str, config: &DefaultValues, tag: &mp4ameta::Tag) -> R
         Err(err) => {
             if config.execution.stop_on_error.unwrap_or(true) {
                 return Err(err)
-                    .context(format!("Unable to rename {filename} with tags \"{pattern}\""));
+                    .with_context(|| format!("Unable to rename {filename} with tags \"{pattern}\""));
             }
             log::warn!(
                 "Unable to rename {filename} with tags \"{pattern}\": {err:#} Continuing."

--- a/id3tag/src/formats/mp4.rs
+++ b/id3tag/src/formats/mp4.rs
@@ -3,8 +3,8 @@
 use crate::default_values::DefaultValues;
 use crate::formats::images;
 use crate::rename_file;
-use mp4ameta::{Data, Fourcc, ImgFmt, Tag};
 use anyhow::{bail, Result};
+use mp4ameta::{Data, Fourcc, ImgFmt, Tag};
 use std::collections::HashMap;
 
 /// Performs the actual processing of MP4 files.
@@ -118,11 +118,7 @@ fn set_picture(tags: &mut Tag, filename: &str) -> Result<()> {
 }
 
 /// Renames the MP4 file based on the pattern provided
-fn rename_file(
-    filename: &str,
-    config: &DefaultValues,
-    tag: &mp4ameta::Tag,
-) -> Result<()> {
+fn rename_file(filename: &str, config: &DefaultValues, tag: &mp4ameta::Tag) -> Result<()> {
     let tags_map = get_mp4_tags(tag);
     log::debug!("tags_map = {tags_map:?}");
 

--- a/id3tag/src/formats/mp4.rs
+++ b/id3tag/src/formats/mp4.rs
@@ -3,7 +3,7 @@
 use crate::default_values::DefaultValues;
 use crate::formats::images;
 use crate::rename_file;
-use anyhow::{bail, Result};
+use anyhow::{bail, Context, Result};
 use mp4ameta::{Data, Fourcc, ImgFmt, Tag};
 use std::collections::HashMap;
 
@@ -76,9 +76,9 @@ pub fn process(
             Ok(()) => processed_ok = true,
             Err(err) => {
                 if config.execution.stop_on_error.unwrap_or(true) {
-                    bail!("Unable to save tags to {filename}. Error: {err}");
+                    return Err(err).context(format!("Unable to save tags to {filename}"));
                 }
-                log::warn!("Unable to save tags to {filename}. Error: {err}");
+                log::warn!("Unable to save tags to {filename}: {err:#}");
             }
         }
     }
@@ -89,9 +89,9 @@ pub fn process(
             Ok(()) => processed_ok = true,
             Err(err) => {
                 if config.execution.stop_on_error.unwrap_or(true) {
-                    bail!("Unable to rename {filename}. Error: {err}");
+                    return Err(err).context(format!("Unable to rename {filename}"));
                 }
-                log::warn!("Unable to rename {filename}. Error: {err}");
+                log::warn!("Unable to rename {filename}: {err:#}");
             }
         }
     }
@@ -132,10 +132,11 @@ fn rename_file(filename: &str, config: &DefaultValues, tag: &mp4ameta::Tag) -> R
         Ok(new_filename) => log::info!("{filename} --> {new_filename}"),
         Err(err) => {
             if config.execution.stop_on_error.unwrap_or(true) {
-                bail!("Unable to rename {filename} with tags \"{pattern}\". Error: {err}");
+                return Err(err)
+                    .context(format!("Unable to rename {filename} with tags \"{pattern}\""));
             }
             log::warn!(
-                "Unable to rename {filename} with tags \"{pattern}\". Error: {err} Continuing."
+                "Unable to rename {filename} with tags \"{pattern}\": {err:#} Continuing."
             );
         }
     }

--- a/id3tag/src/main.rs
+++ b/id3tag/src/main.rs
@@ -8,8 +8,8 @@
 #![warn(clippy::pedantic)]
 #![forbid(unsafe_code)]
 
+use anyhow::{bail, Result};
 use clap::ArgMatches;
-use std::error::Error;
 use std::time::Instant;
 
 // Local modules
@@ -26,7 +26,7 @@ use thousands::Separable;
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////
 /// This is where the magic happens.
 #[allow(clippy::cast_precision_loss)] // for  `let el = elapsed as f64 / 1000.0;`
-fn run() -> Result<(), Box<dyn Error>> {
+fn run() -> Result<()> {
     // Start timing the execution
     let now = Instant::now();
 
@@ -36,9 +36,7 @@ fn run() -> Result<(), Box<dyn Error>> {
     let binding = String::new();
     let pattern = cli.get_one::<String>("rename-file").unwrap_or(&binding);
     if cli.contains_id("rename-file") && file_rename_pattern_not_ok(pattern) {
-        return Err(
-            format!("File rename pattern {pattern} likely won't create unique files.").into(),
-        );
+        bail!("File rename pattern {pattern} likely won't create unique files.");
     }
 
     // Build the config -- read the CLI arguments and the config file if one is provided.
@@ -126,9 +124,8 @@ fn main() {
     std::process::exit(match run() {
         Ok(()) => 0, // everying is hunky dory - exit with code 0 (success)
         Err(err) => {
-            let msg = err.to_string().replace('\"', "");
-            log::error!("{msg}");
-            eprintln!("Error: {msg}");
+            log::error!("{err:#}");
+            eprintln!("Error: {err:#}");
             1 // exit with a non-zero return code, indicating a problem
         }
     });

--- a/id3tag/src/main.rs
+++ b/id3tag/src/main.rs
@@ -124,8 +124,9 @@ fn main() {
     std::process::exit(match run() {
         Ok(()) => 0, // everying is hunky dory - exit with code 0 (success)
         Err(err) => {
-            log::error!("{err:#}");
-            eprintln!("Error: {err:#}");
+            let msg = format!("{err:#}").replace('"', "");
+            log::error!("{msg}");
+            eprintln!("Error: {msg}");
             1 // exit with a non-zero return code, indicating a problem
         }
     });

--- a/id3tag/src/rename_file.rs
+++ b/id3tag/src/rename_file.rs
@@ -1,4 +1,4 @@
-use anyhow::{bail, Result};
+use anyhow::{bail, Context, Result};
 use std::{collections::HashMap, path::Path};
 
 use crate::default_values::DefaultValues;
@@ -111,9 +111,9 @@ pub fn rename_file(
             Ok(()) => log::debug!("{filename} --> {npl}"),
             Err(err) => {
                 if config.execution.stop_on_error.unwrap_or(true) {
-                    bail!("Unable to rename {filename} to {npl}. Error: {err}");
+                    return Err(err).context(format!("Unable to rename {filename} to {npl}"));
                 }
-                log::warn!("Unable to rename {filename} to {npl}. Error: {err}");
+                log::warn!("Unable to rename {filename} to {npl}: {err:#}");
             }
         }
     }

--- a/id3tag/src/rename_file.rs
+++ b/id3tag/src/rename_file.rs
@@ -111,7 +111,7 @@ pub fn rename_file(
             Ok(()) => log::debug!("{filename} --> {npl}"),
             Err(err) => {
                 if config.execution.stop_on_error.unwrap_or(true) {
-                    return Err(err).context(format!("Unable to rename {filename} to {npl}"));
+                    return Err(err).with_context(|| format!("Unable to rename {filename} to {npl}"));
                 }
                 log::warn!("Unable to rename {filename} to {npl}: {err:#}");
             }

--- a/id3tag/src/rename_file.rs
+++ b/id3tag/src/rename_file.rs
@@ -1,4 +1,5 @@
-use std::{collections::HashMap, error::Error, path::Path};
+use anyhow::{bail, Result};
+use std::{collections::HashMap, path::Path};
 
 use crate::default_values::DefaultValues;
 
@@ -28,12 +29,12 @@ pub fn rename_file(
     filename: &str,
     tags: &HashMap<String, String>,
     config: &DefaultValues,
-) -> Result<String, Box<dyn Error>> {
+) -> Result<String> {
     // Check if there is a rename pattern
     let mut new_filename = if let Some(nfn) = &config.rename_file {
         nfn.clone()
     } else {
-        return Err("No filename pattern presented. Unable to continue.".into());
+        bail!("No filename pattern presented. Unable to continue.");
     };
 
     // Check if any tag used in the pattern is empty. If so, skip the rename.
@@ -110,9 +111,7 @@ pub fn rename_file(
             Ok(()) => log::debug!("{filename} --> {npl}"),
             Err(err) => {
                 if config.execution.stop_on_error.unwrap_or(true) {
-                    return Err(
-                        format!("Unable to rename {filename} to {npl}. Error: {err}").into(),
-                    );
+                    bail!("Unable to rename {filename} to {npl}. Error: {err}");
                 }
                 log::warn!("Unable to rename {filename} to {npl}. Error: {err}");
             }


### PR DESCRIPTION
Closes crumb id3-chf.

## Summary

- Adds `anyhow = "1"` to workspace dependencies
- Replaces `Result<T, Box<dyn Error>>` with `anyhow::Result<T>` across all five crates (~60 function signatures, 28+ files)
- `bail!()` replaces `Err("...".into())` and `Err(format!(...).into())` (46+ constructions)
- `.with_context()` replaces `.map_err(|e| format!(...))` (3 sites in `common` and `id3tag`)
- `main()` error display upgraded to `{err:#}` in all four binaries — richer cause-chain output
- `id3export/stats.rs` also migrated (compiler requirement: `csv::Error` is not `Send+Sync`)

No application behaviour changes except richer error cause-chain output when errors are displayed.

## Test plan

- [x] `cargo test --workspace` — 48 tests pass, zero failures
- [x] `cargo clippy --workspace -- -D warnings` — zero warnings
- [x] `cargo build --workspace --release` — all four binaries build
- [ ] Manual smoke test: `id3tag --rename-file '%n' <sample.mp3>` — error message unchanged