### PR TITLE
fix(clippy): remove unnecessary trailing commas in log macros in dsf.rs

### DIFF
--- a/id3tag/src/formats/dsf.rs
+++ b/id3tag/src/formats/dsf.rs
@@ -170,7 +170,7 @@ fn rename_file(filename: &str, config: &DefaultValues, tag: &id3::Tag) -> Result
                     format!("Unable to rename {filename} with tags \"{pattern}\"")
                 });
             }
-            log::warn!("Unable to rename {filename} with tags \"{pattern}\": {err:#} Continuing.",);
+            log::warn!("Unable to rename {filename} with tags \"{pattern}\": {err:#} Continuing.");
         }
     }
 
@@ -199,7 +199,7 @@ fn to_number(value: &str, item: &str, stop_on_error: bool) -> Result<u32> {
             if stop_on_error {
                 return Err(err).with_context(|| format!("Unable to set {item} to {value}"));
             }
-            log::error!("Unable to set {item} to {value}. Setting to 1 and continuing: {err:#}",);
+            log::error!("Unable to set {item} to {value}. Setting to 1 and continuing: {err:#}");
             1
         }
     };


### PR DESCRIPTION
## Summary

- Clippy's `unnecessary_trailing_comma` lint (introduced in Rust 1.96) now flags trailing commas after the last format string in macro invocations
- Removes the trailing `,` from `log::warn!` (line 173) and `log::error!` (line 202) in `id3tag/src/formats/dsf.rs`
- This is a pre-existing issue on `main` that is blocking two open Dependabot PRs (#47, #49) from passing Clippy CI

## Test plan

- [ ] Clippy check passes on CI after merge
- [ ] Dependabot PRs #47 and #49 can be rebased and merged once this lands on `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)