### PR TITLE
fix(id3show): standardise output to colon separator with units

### DIFF
--- a/docs/plans/2026-06-30-audio-info-block-for-flac.md
+++ b/docs/plans/2026-06-30-audio-info-block-for-flac.md
@@ -128,11 +128,11 @@ fn show_audio_info(si: &block::StreamInfo, file_size: u64) -> Result<()> {
     let bitrate       = calc_bitrate_kbps(file_size, duration_secs);
 
     println!("  Audio Info:");
-    println!("    Channels    = {}", si.num_channels);
-    println!("    Sample Rate = {} Hz", si.sample_rate);
-    println!("    Bit Depth   = {} bits", si.bits_per_sample);
-    println!("    Bitrate     = {} kbps", bitrate);
-    println!("    Duration    = {duration_str}");
+    println!("    Channels: {}", si.num_channels);
+    println!("    Sample Rate: {} Hz", si.sample_rate);
+    println!("    Bit Depth: {} bits", si.bits_per_sample);
+    println!("    Bitrate: {} kbps", bitrate);
+    println!("    Duration: {duration_str}");
     Ok(())
 }
 ```
@@ -165,8 +165,8 @@ metaflac::Block::StreamInfo(si) => {
 Change the trailing `println!` in `show_vorbis_comment` from unconditional to:
 
 ```rust
-if !show_detail {
-    println!("    Duration = {duration} mm:ss");
+if show_duration {
+    println!("    Duration: {duration}");
 }
 ```
 
@@ -239,17 +239,17 @@ fn test_calc_duration_string_hours() {
 ```
 some-track.flac
   Audio Info:
-    Channels    = 2
-    Sample Rate = 44100 Hz
-    Bit Depth   = 16 bits
-    Bitrate     = 812 kbps
-    Duration    = 05:23
+    Channels: 2
+    Sample Rate: 44100 Hz
+    Bit Depth: 16 bits
+    Bitrate: 812 kbps
+    Duration: 05:23
   Stream Info:
     Min Block Size: 4096
     ...
   Vorbis Comments:
-    ARTIST = Toto
-    ALBUM  = Toto IV
+    ARTIST: Toto
+    ALBUM: Toto IV
     ...
     (Duration no longer repeated here)
 ```

--- a/id3show/src/ape.rs
+++ b/id3show/src/ape.rs
@@ -33,10 +33,10 @@ pub fn show_metadata(filename: &str, show_detail: bool) -> Result<()> {
                     if item.get_type() == ItemType::Locator {
                         if show_detail {
                             println!("  Locator:");
-                            println!("    {} = {s}", item.key);
+                            println!("    {}: {s}", item.key);
                         }
                     } else {
-                        println!("  {} = {s}", item.key);
+                        println!("  {}: {s}", item.key);
                     }
                 }
             }
@@ -44,7 +44,7 @@ pub fn show_metadata(filename: &str, show_detail: bool) -> Result<()> {
                 if show_detail {
                     let bytes: Vec<u8> = item.into();
                     println!("  Binary:");
-                    println!("    {} = {} bytes", item.key, bytes.len());
+                    println!("    {}: {} bytes", item.key, bytes.len());
                 }
             }
         }

--- a/id3show/src/dsf.rs
+++ b/id3show/src/dsf.rs
@@ -20,7 +20,7 @@ pub fn show_metadata(filename: &str, show_detail: bool) -> Result<()> {
     } else if let Some(tag) = DsfFile::open(path)?.id3_tag().clone() {
         log::debug!("Tag: {tag:?}");
         for frame in tag.frames() {
-            println!("  {} = {}", frame.id(), frame.content());
+            println!("  {}: {}", frame.id(), frame.content());
         }
     } else {
         bail!("Unable to read DSF file {filename}");

--- a/id3show/src/flac.rs
+++ b/id3show/src/flac.rs
@@ -128,14 +128,14 @@ fn calc_bitrate_kbps(file_size: u64, duration_secs: f64) -> u32 {
 /// Show the `block::StreamInfo` fields
 fn show_streaminfo(si: &block::StreamInfo) {
     println!("  Stream Info:");
-    println!("    Min Block Size: {}", si.min_block_size);
-    println!("    Max Block Size: {}", si.max_block_size);
+    println!("    Min Block Size: {} samples", si.min_block_size);
+    println!("    Max Block Size: {} samples", si.max_block_size);
     println!("    Min Frame Size: {} bytes", si.min_frame_size);
     println!("    Max Frame Size: {} bytes", si.max_frame_size);
     println!("    Sample Rate: {} Hz", si.sample_rate);
     println!("    Channels: {}", si.num_channels);
-    println!("    Bits Per Sample: {}", si.bits_per_sample);
-    println!("    Total Samples: {}", si.total_samples);
+    println!("    Bits Per Sample: {} bits", si.bits_per_sample);
+    println!("    Total Samples: {} samples", si.total_samples);
     println!("    MD5: {:?}", si.md5);
 }
 
@@ -170,7 +170,7 @@ fn show_picture(pic: &block::Picture) {
     println!("    Width: {} px", pic.width);
     println!("    Height: {} px", pic.height);
     println!("    Color Depth: {} bits", pic.depth);
-    println!("    Color Count: {}", pic.num_colors);
+    println!("    Color Count: {} colors", pic.num_colors);
     println!("    Picture Size: {} bytes", pic.data.len());
 }
 
@@ -218,10 +218,7 @@ fn calc_duration_seconds(samples: u64, sample_rate: u32) -> Result<f64> {
 }
 
 fn calc_duration_string(samples: u64, sample_rate: u32) -> Result<String> {
-    Ok(format_duration(calc_duration_seconds(
-        samples,
-        sample_rate,
-    )?))
+    Ok(format_duration(calc_duration_seconds(samples, sample_rate)?))
 }
 
 /// Format a duration given in seconds as `mm:ss` or `hh:mm:ss` (zero-padded).

--- a/id3show/src/flac.rs
+++ b/id3show/src/flac.rs
@@ -95,11 +95,11 @@ fn show_audio_info(si: &block::StreamInfo, file_size: u64) -> Result<()> {
     let bitrate = calc_bitrate_kbps(file_size, duration_secs);
 
     println!("  Audio Info:");
-    println!("    Channels    = {}", si.num_channels);
-    println!("    Sample Rate = {} Hz", si.sample_rate);
-    println!("    Bit Depth   = {} bits", si.bits_per_sample);
-    println!("    Bitrate     = {} kbps", bitrate);
-    println!("    Duration    = {duration_str}");
+    println!("    Channels: {}", si.num_channels);
+    println!("    Sample Rate: {} Hz", si.sample_rate);
+    println!("    Bit Depth: {} bits", si.bits_per_sample);
+    println!("    Bitrate: {} kbps", bitrate);
+    println!("    Duration: {duration_str}");
     Ok(())
 }
 
@@ -130,9 +130,9 @@ fn show_streaminfo(si: &block::StreamInfo) {
     println!("  Stream Info:");
     println!("    Min Block Size: {}", si.min_block_size);
     println!("    Max Block Size: {}", si.max_block_size);
-    println!("    Min Frame Size: {}", si.min_frame_size);
-    println!("    Max Frame Size: {}", si.max_frame_size);
-    println!("    Sample Rate: {}", si.sample_rate);
+    println!("    Min Frame Size: {} bytes", si.min_frame_size);
+    println!("    Max Frame Size: {} bytes", si.max_frame_size);
+    println!("    Sample Rate: {} Hz", si.sample_rate);
     println!("    Channels: {}", si.num_channels);
     println!("    Bits Per Sample: {}", si.bits_per_sample);
     println!("    Total Samples: {}", si.total_samples);
@@ -158,7 +158,7 @@ fn show_cuesheet(cs: &block::CueSheet) {
 /// Show the `block::Padding` fields
 fn show_padding(pad: u32) {
     println!("  Padding:");
-    println!("    Padding Size: {pad}");
+    println!("    Padding Size: {pad} bytes");
 }
 
 /// Show the `block::Picture` fields
@@ -167,11 +167,11 @@ fn show_picture(pic: &block::Picture) {
     println!("    Picture Type: {:?}", pic.picture_type);
     println!("    MIME Type: {}", pic.mime_type);
     println!("    Description: {}", pic.description);
-    println!("    Width: {}", pic.width);
-    println!("    Height: {}", pic.height);
-    println!("    Color Depth: {}", pic.depth);
+    println!("    Width: {} px", pic.width);
+    println!("    Height: {} px", pic.height);
+    println!("    Color Depth: {} bits", pic.depth);
     println!("    Color Count: {}", pic.num_colors);
-    println!("    Picture size: {} bytes", pic.data.len());
+    println!("    Picture Size: {} bytes", pic.data.len());
 }
 
 /// Show the `block::SeekTable` fields
@@ -181,18 +181,23 @@ fn show_seektable(st: &block::SeekTable) {
 }
 
 /// Show the `block::VorbisComment` fields
-fn show_vorbis_comment(vc: &block::VorbisComment, duration: &str, show_detail: bool, show_duration: bool) {
+fn show_vorbis_comment(
+    vc: &block::VorbisComment,
+    duration: &str,
+    show_detail: bool,
+    show_duration: bool,
+) {
     println!("  Vorbis Comments:");
     if show_detail {
         println!("    Vendor: {}", vc.vendor_string);
     }
     for (key, values) in &vc.comments {
         for value in values {
-            println!("    {key} = {value}");
+            println!("    {key}: {value}");
         }
     }
     if show_duration {
-        println!("    Duration = {duration}");
+        println!("    Duration: {duration}");
     }
 }
 
@@ -213,7 +218,10 @@ fn calc_duration_seconds(samples: u64, sample_rate: u32) -> Result<f64> {
 }
 
 fn calc_duration_string(samples: u64, sample_rate: u32) -> Result<String> {
-    Ok(format_duration(calc_duration_seconds(samples, sample_rate)?))
+    Ok(format_duration(calc_duration_seconds(
+        samples,
+        sample_rate,
+    )?))
 }
 
 /// Format a duration given in seconds as `mm:ss` or `hh:mm:ss` (zero-padded).

--- a/id3show/src/mp3.rs
+++ b/id3show/src/mp3.rs
@@ -76,19 +76,19 @@ pub fn show_metadata(filename: &str, show_detail: bool) -> Result<()> {
     for item in tag.frames() {
         match item.content() {
             Content::Text(t) => {
-                println!("  {} = {t} (Text)", item.name());
+                println!("  {}: {t} (Text)", item.name());
             }
             Content::ExtendedText(et) => {
-                println!("  {} = {et} (Extended Text)", item.name());
+                println!("  {}: {et} (Extended Text)", item.name());
             }
             Content::Link(l) => {
-                println!("  {} = {l} (Link)", item.name());
+                println!("  {}: {l} (Link)", item.name());
             }
             Content::ExtendedLink(el) => {
-                println!("  {} = {el} (Extended Link)", item.name());
+                println!("  {}: {el} (Extended Link)", item.name());
             }
             Content::Comment(co) => {
-                println!("  {} = {co} (Comment)", item.name());
+                println!("  {}: {co} (Comment)", item.name());
             }
             Content::Popularimeter(pm) => {
                 if show_detail {
@@ -137,7 +137,7 @@ pub fn show_metadata(filename: &str, show_detail: bool) -> Result<()> {
     }
 
     if !show_detail {
-        println!("  Duration = {duration_string} (Calc)");
+        println!("  Duration: {duration_string} (Calc)");
     }
 
     // return safely

--- a/id3show/src/mp4.rs
+++ b/id3show/src/mp4.rs
@@ -10,39 +10,39 @@ pub fn show_metadata(filename: &str, show_detail: bool) -> Result<()> {
         match data {
             mp4ameta::Data::Reserved(res) => {
                 if show_detail {
-                    println!("  {data_ident} = {res:?} (Reserved)");
+                    println!("  {data_ident}: {res:?} (Reserved)");
                 }
             }
             mp4ameta::Data::Utf8(d) => {
-                println!("  {data_ident} = {d} (UTF-8)");
+                println!("  {data_ident}: {d} (UTF-8)");
             }
             mp4ameta::Data::Utf16(d) => {
-                println!("  {data_ident} = {d} (UTF-16)");
+                println!("  {data_ident}: {d} (UTF-16)");
             }
             mp4ameta::Data::Jpeg(jpeg) => {
                 if show_detail {
-                    println!("  {} = {} bytes (JPEG)", data_ident, jpeg.len());
+                    println!("  {}: {} bytes (JPEG)", data_ident, jpeg.len());
                 }
             }
             mp4ameta::Data::Png(png) => {
                 if show_detail {
-                    println!("  {} = {} bytes (PNG)", data_ident, png.len());
+                    println!("  {}: {} bytes (PNG)", data_ident, png.len());
                 }
             }
             mp4ameta::Data::BeSigned(bes) => {
                 if show_detail {
-                    println!("  {} = {} bytes (Big-Endian Signed)", data_ident, bes.len());
+                    println!("  {}: {} bytes (Big-Endian Signed)", data_ident, bes.len());
                 }
             }
             mp4ameta::Data::Bmp(bmp) => {
                 if show_detail {
-                    println!("  {} = {} bytes (BMP)", data_ident, bmp.len());
+                    println!("  {}: {} bytes (BMP)", data_ident, bmp.len());
                 }
             }
             mp4ameta::Data::Unknown { code, data } => {
                 if show_detail {
                     println!(
-                        "  {data_ident} = {len} bytes (Unknown, code={code})",
+                        "  {data_ident}: {len} bytes (Unknown, code={code})",
                         len = data.len()
                     );
                 }

--- a/id3show/src/mp4.rs
+++ b/id3show/src/mp4.rs
@@ -5,7 +5,7 @@ use mp4ameta::Tag;
 pub fn show_metadata(filename: &str, show_detail: bool) -> Result<()> {
     let tag = Tag::read_from_path(filename)?;
 
-    log::trace!("Tag = {tag:?}");
+    log::trace!("Tag: {tag:?}");
     for (data_ident, data) in tag.data() {
         match data {
             mp4ameta::Data::Reserved(res) => {


### PR DESCRIPTION
## Summary

- Replace all hardcoded ` = ` separators with `: ` across every `show_*` function in all five format handlers (FLAC, MP3, APE, DSF, MP4) — tag key/value pairs, frame content, and computed labels are now consistent
- Add units where the raw number was ambiguous:
  - **Stream Info:** `Sample Rate` → Hz, `Min/Max Frame Size` → bytes
  - **Picture:** `Width`/`Height` → px, `Color Depth` → bits, capitalise `Picture Size`
  - **Padding:** `Padding Size` → bytes

## Test plan

- [ ] `cargo build -p id3show` — zero warnings ✅
- [ ] `cargo clippy -p id3show -- -D warnings` — clean ✅
- [ ] `cargo test -p id3show` — 6/6 pass ✅
- [ ] Manual smoke test with FLAC, MP3, APE, and MP4 files to confirm consistent `: ` output

🤖 Generated with [Claude Code](https://claude.com/claude-code)